### PR TITLE
cloud-hypervisor: add platformOEMStrings and `--platform` merging

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -107,7 +107,7 @@ rec {
       => { values = ["linux"]; args = ["-vnc" ":0" "-usb"]; }
 
       # Extract multiple occurrences:
-      extractOptValues "-platform" ["-a" "a" "-b" "b" "-c" "c" "-b" "b2"]
+      extractOptValues "-b" ["-a" "a" "-b" "b" "-c" "c" "-b" "b2"]
       => { values = ["b" "b2"]; args = ["-b" "b" "-c" "c"]; }
 
       # Extract with multiple flag aliases:

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -108,7 +108,7 @@ rec {
 
       # Extract multiple occurrences:
       extractOptValues "-b" ["-a" "a" "-b" "b" "-c" "c" "-b" "b2"]
-      => { values = ["b" "b2"]; args = ["-b" "b" "-c" "c"]; }
+      => { values = ["b" "b2"]; args = ["-a" "a" "-c" "c"]; }
 
       # Extract with multiple flag aliases:
       extractOptValues ["-p" "-platform"] ["-p" "short" "-vnc" ":0" "-platform" "long" "-usb"]

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -78,4 +78,59 @@ rec {
     import ./macvtap.nix {
       inherit microvmConfig hypervisorConfig lib;
     };
+
+  /*
+    extractOptValues - Extract and remove all occurrences of a command-line option and its values from a list of arguments.
+
+    Description:
+      This function searches for a specified option flag in a list of command-line arguments,
+      extracts ALL associated values, and returns both the values and a filtered list with
+      all occurrences of the option flag and its values removed. The order of all other
+      arguments is preserved. Uses tail recursion to process the argument list.
+
+    Parameters:
+      optFlag :: String | [String] - The option flag(s) to search for. Can be:
+                                     - A single string (e.g., "-platform")
+                                     - A list of strings (e.g., ["-p" "-platform"])
+                                     All matching flags and their values are extracted
+      extraArgs :: [String] - A list of command-line arguments
+
+    Returns:
+      {
+        values :: [String] - List of all values associated with matching flags (empty list if none found)
+        args :: [String] - The input list with all matched flags and their values removed
+      }
+
+    Examples:
+      # Extract single occurrence:
+      extractOptValues "-platform" ["-vnc" ":0" "-platform" "linux" "-usb"]
+      => { values = ["linux"]; args = ["-vnc" ":0" "-usb"]; }
+
+      # Extract multiple occurrences:
+      extractOptValues "-platform" ["-a" "a" "-b" "b" "-c" "c" "-b" "b2"]
+      => { values = ["b" "b2"]; args = ["-b" "b" "-c" "c"]; }
+
+      # Extract with multiple flag aliases:
+      extractOptValues ["-p" "-platform"] ["-p" "short" "-vnc" ":0" "-platform" "long" "-usb"]
+      => { values = ["short" "long"]; args = ["-vnc" ":0" "-usb"]; }
+
+      # Degenerate case with no matches:
+      extractOptValues ["-p" "-platform"] ["-vnc" ":0" "-usb"]
+      => { values = []; args = ["-vnc" ":0" "-usb"]; }
+  */
+  extractOptValues = optFlag: extraArgs:
+    let
+      flags = if builtins.isList optFlag then optFlag else [optFlag];
+
+      processArgs = args: values: acc:
+        if args == [] then
+          { values = values; args = acc; }
+        else if (builtins.elem (builtins.head args) flags) && (builtins.length args) > 1 then
+          # Found one of the option flags, skip it and its value
+          processArgs (builtins.tail (builtins.tail args)) (values ++ [(builtins.elemAt args 1)]) acc
+        else
+          # Not the option we're looking for, keep this element
+          processArgs (builtins.tail args) values (acc ++ [(builtins.head args)]);
+    in
+      processArgs extraArgs [] [];
 }

--- a/lib/runner.nix
+++ b/lib/runner.nix
@@ -8,13 +8,13 @@ let
 
   inherit (microvmConfig) hostName;
 
-  inherit (import ./. { inherit lib; }) createVolumesScript makeMacvtap withDriveLetters;
+  inherit (import ./. { inherit lib; }) createVolumesScript makeMacvtap withDriveLetters extractOptValues;
   inherit (makeMacvtap {
     inherit microvmConfig hypervisorConfig;
   }) openMacvtapFds macvtapFds;
 
   hypervisorConfig = import (./runners + "/${microvmConfig.hypervisor}.nix") {
-    inherit pkgs microvmConfig macvtapFds withDriveLetters;
+    inherit pkgs microvmConfig macvtapFds withDriveLetters extractOptValues;
   };
 
   inherit (hypervisorConfig) command canShutdown shutdownCommand;

--- a/lib/runners/cloud-hypervisor.nix
+++ b/lib/runners/cloud-hypervisor.nix
@@ -7,7 +7,7 @@
 let
   inherit (pkgs) lib;
   inherit (microvmConfig) vcpu mem balloon initialBalloonMem deflateOnOOM hotplugMem hotpluggedMem user interfaces volumes shares socket devices hugepageMem graphics storeDisk storeOnDisk kernel initrdPath;
-  inherit (microvmConfig.cloud-hypervisor) extraArgs;
+  inherit (microvmConfig.cloud-hypervisor) platformOEMStrings extraPlatformOpts extraArgs;
 
   kernelPath = {
     x86_64-linux = "${kernel.dev}/vmlinux";
@@ -94,6 +94,9 @@ let
 
   supportsNotifySocket = true;
 
+  oemStringValues = (lib.optionals supportsNotifySocket ["io.systemd.credential:vmm.notify_socket=vsock-stream:2:8888"]) ++ platformOEMStrings;
+  oemStringOptions = lib.optionals  (oemStringValues != [])  ["oem_strings=[${lib.concatStringsSep "," oemStringValues}]"];
+  platformOps = lib.concatStringsSep "," (oemStringOptions ++ extraPlatformOpts);
 in {
   inherit tapMultiQueue;
 
@@ -147,10 +150,10 @@ in {
         "--cmdline" "${kernelConsole} reboot=t panic=-1 ${builtins.unsafeDiscardStringContext (toString microvmConfig.kernelParams)}"
         "--seccomp" "true"
         "--memory" memOps
+        "--platform" platformOps
       ]
       ++
       lib.optionals supportsNotifySocket [
-        "--platform" "oem_strings=[io.systemd.credential:vmm.notify_socket=vsock-stream:2:8888]"
         "--vsock" "cid=3,socket=notify.vsock"
       ]
       ++

--- a/nixos-modules/microvm/asserts.nix
+++ b/nixos-modules/microvm/asserts.nix
@@ -105,7 +105,16 @@ lib.mkIf config.microvm.guest.enable {
       message = ''
         MicroVM ${hostName}: `config.microvm.forwardPorts` works only with qemu and one network interface with `type = "user"`
       '';
+    } ]
+    ++
+    # cloud-hypervisor specific asserts
+    lib.optionals (config.microvm.hypervisor == "cloud-hypervisor") [ {
+      assertion = ! (lib.any (str: lib.hasInfix "oem_strings" str) config.microvm.cloud-hypervisor.platformOEMStrings);
+      message = ''
+        MicroVM ${hostName}: `config.microvm.cloud-hypervisor.platformOEMStrings` items must not contain `oem_strings`
+      '';
     } ];
+
 
   warnings =
     # 32 MB is just an optimistic guess, not based on experience

--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -519,24 +519,17 @@ in
       type = with types; listOf str;
       default = [];
       description = ''
-      Extra arguments to pass to cloud-hypervisor's --platform oem_strings= argument.
+        Extra arguments to pass to cloud-hypervisor's --platform oem_strings= argument.
 
-      All the oem strings will be concatenated with a comma (,) and wrapped in oem_string=[].
+        All the oem strings will be concatenated with a comma (,) and wrapped in oem_string=[].
+
+        The resulting string will be combined with any --platform options in
+        `config.microvm.cloud-hypervisor.extraArgs` and passed as a single
+        --platform option to cloud-hypervisor
       '';
-      example = literalExpression /* nix */ ''
-      [ "io.systemd.credential:APIKEY=supersecret" ]
-      '';
-    };
-    cloud-hypervisor.extraPlatformOpts = mkOption {
-      type = with types; listOf str;
-      default = [];
-      description = ''
-      Extra arguments to pass to cloud-hypervisor's --platform argument.
-      All --platform args will be concatended with a comma (,).
-      '';
-      example = literalExpression /* nix */ ''
-      [ "uuid=<dmi_device_uuid>" ]
-      '';
+      example = lib.literalExpression /* nix */ ''
+          [ "io.systemd.credential:APIKEY=supersecret" ]
+        '';
     };
 
     cloud-hypervisor.extraArgs = mkOption {

--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -515,6 +515,30 @@ in
       '';
     };
 
+    cloud-hypervisor.platformOEMStrings = mkOption {
+      type = with types; listOf str;
+      default = [];
+      description = ''
+      Extra arguments to pass to cloud-hypervisor's --platform oem_strings= argument.
+
+      All the oem strings will be concatenated with a comma (,) and wrapped in oem_string=[].
+      '';
+      example = literalExpression /* nix */ ''
+      [ "io.systemd.credential:APIKEY=supersecret" ]
+      '';
+    };
+    cloud-hypervisor.extraPlatformOpts = mkOption {
+      type = with types; listOf str;
+      default = [];
+      description = ''
+      Extra arguments to pass to cloud-hypervisor's --platform argument.
+      All --platform args will be concatended with a comma (,).
+      '';
+      example = literalExpression /* nix */ ''
+      [ "uuid=<dmi_device_uuid>" ]
+      '';
+    };
+
     cloud-hypervisor.extraArgs = mkOption {
       type = with types; listOf str;
       default = [];

--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -519,17 +519,17 @@ in
       type = with types; listOf str;
       default = [];
       description = ''
-        Extra arguments to pass to cloud-hypervisor's --platform oem_strings= argument.
+        Extra arguments to pass to cloud-hypervisor's --platform oem_strings=[] argument.
 
         All the oem strings will be concatenated with a comma (,) and wrapped in oem_string=[].
+
+        Do not include oem_string= or the [] brackets in the value.
 
         The resulting string will be combined with any --platform options in
         `config.microvm.cloud-hypervisor.extraArgs` and passed as a single
         --platform option to cloud-hypervisor
       '';
-      example = lib.literalExpression /* nix */ ''
-          [ "io.systemd.credential:APIKEY=supersecret" ]
-        '';
+      example = lib.literalExpression /* nix */ ''[ "io.systemd.credential:APIKEY=supersecret" ]'';
     };
 
     cloud-hypervisor.extraArgs = mkOption {


### PR DESCRIPTION
The cloud-hypervisor command line interface unfortunately doesn't support
multiple instances of the same arg with a different value, so we have to resort
to these extra module options rather than using extraArgs.

To make matters even worse, the `--platform` argument (of which there can be
only one), is overloaded with different types of sub-args that also need to be
provided multiple times.

This commit allows the operator to add oem strings (for example to pass systemd
credentials), as well as raw platform options as needed.
