### PR TITLE
Add option to pass cpu-config to firecracker

### DIFF
--- a/lib/runners/firecracker.nix
+++ b/lib/runners/firecracker.nix
@@ -11,11 +11,14 @@ let
     interfaces volumes shares devices
     kernel initrdPath
     storeDisk;
+  inherit (microvmConfig.firecracker) cpuConfig;
 
   kernelPath = {
     x86_64-linux = "${kernel.dev}/vmlinux";
     aarch64-linux = "${kernel.out}/${pkgs.stdenv.hostPlatform.linux-kernel.target}";
   }.${system};
+
+  cpu-config = lib.optionalAttrs (cpuConfig != null) pkgs.writeText "cpu-config.json" (builtins.toJSON cpuConfig);
 
   # Firecracker config, as JSON in `configFile`
   config = {
@@ -60,6 +63,7 @@ let
       else throw "Network interface type ${type} not implemented for Firecracker"
     ) interfaces;
     vsock = null;
+    inherit cpu-config;
   };
 
   configFile = pkgs.writers.writeJSON "firecracker-${hostName}.json" config;

--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -533,6 +533,12 @@ in
       description = "A Hypervisor's sandbox directory";
     };
 
+    firecracker.cpuConfig = mkOption {
+      type = with types; nullOr attrs;
+      default = null;
+      description = "Custom CPU template passed to firecracker.";
+    };
+
     prettyProcnames = mkOption {
       type = types.bool;
       default = true;


### PR DESCRIPTION
Add new option to pass custom [cpu-config](https://github.com/firecracker-microvm/firecracker/blob/7dfe2765849c2444a22defa11be8641508c5ce5c/docs/cpu_templates/cpu-templates.md#custom-cpu-templates) JSON to firecracker.