### PR TITLE
Fix credentialFiles option in QEMU not working when more than one credential is provided

### DIFF
--- a/lib/runners/qemu.nix
+++ b/lib/runners/qemu.nix
@@ -190,9 +190,7 @@ lib.warnIf (mem == 2048) ''
       "-chardev" "stdio,id=stdio,signal=off"
       "-device" "virtio-rng-${devType}"
     ] ++
-    lib.optionals (fwCfgOptions != [])  [
-      "-fw_cfg" (lib.concatStringsSep "," fwCfgOptions)
-    ] ++
+    builtins.concatMap (x: ["-fw_cfg" x]) fwCfgOptions ++
     lib.optionals serialConsole [
       "-serial" "chardev:stdio"
     ] ++

--- a/lib/runners/qemu.nix
+++ b/lib/runners/qemu.nix
@@ -190,7 +190,7 @@ lib.warnIf (mem == 2048) ''
       "-chardev" "stdio,id=stdio,signal=off"
       "-device" "virtio-rng-${devType}"
     ] ++
-    builtins.concatMap (x: ["-fw_cfg" x]) fwCfgOptions ++
+    builtins.concatMap (fwCfgOption: ["-fw_cfg" fwCfgOption]) fwCfgOptions ++
     lib.optionals serialConsole [
       "-serial" "chardev:stdio"
     ] ++


### PR DESCRIPTION
Hi!

While I was testing some things I encountered an issue with the `credentialFiles` option. It worked fine with 0 or 1 credential, but when I provided 2 credentials, the VM no longer recognized them.

This commit should fix the issue, I tested it with both my configuration (2 credentials) and the `#qemu-example` configuration.