### PR TITLE
cloud-hypervisor: properly advertise support for systemd-notify

### DIFF
--- a/lib/runners/cloud-hypervisor.nix
+++ b/lib/runners/cloud-hypervisor.nix
@@ -139,7 +139,7 @@ let
     else
       lib.concatStringsSep "," (oemStringOptions ++ userPlatformOpts);
 in {
-  inherit tapMultiQueue;
+  inherit tapMultiQueue supportsNotifySocket;
 
   preStart = ''
     ${microvmConfig.preStart}


### PR DESCRIPTION
This seems to have been dropped by mistake: https://github.com/microvm-nix/microvm.nix/pull/379/files#diff-e9029b60b67bf9e6960f7b3b27dc3d266a56c8d089250acce3bfe1ccec94fc25L145

Without this change, you can set a CID for the VM's vsock, but the generated systemd service will still have `Type=simple` and won't wait for the notification.