### PR TITLE
docs: Add "(in MiB)" to `volumes.*.size`

### DIFF
--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -269,7 +269,7 @@ in
           };
           size = mkOption {
             type = int;
-            description = "Volume size if created automatically";
+            description = "Volume size (in MiB) if created automatically";
           };
           autoCreate = mkOption {
             type = bool;


### PR DESCRIPTION
I think there is no further explanation needed :-)