### PR TITLE
Qemu: Select qemu_kvm on Linux hosts

### DIFF
--- a/lib/runners/qemu.nix
+++ b/lib/runners/qemu.nix
@@ -38,8 +38,18 @@ let
     lib.optional requireUsb enableLibusb
     ++ lib.optional microvmConfig.optimize.enable minimizeQemuClosureSize
   );
+  qemuPkg =
+    if microvmConfig.cpu == null && vmHostPackages.stdenv.hostPlatform.isLinux
+    then
+      # If no CPU is requested and the host is Linux,
+      # use qemu with KVM support (hardware-accelerated)
+      vmHostPackages.qemu_kvm
+    else
+      # Different CPU architectures like darwin or Non-Linux
+      # use the generic qemu package
+      vmHostPackages.qemu;
 
-  qemu = overrideQemu vmHostPackages.qemu;
+  qemu = overrideQemu qemuPkg;
 
   aioEngine = if vmHostPackages.stdenv.hostPlatform.isLinux
     then "io_uring"

--- a/lib/runners/qemu.nix
+++ b/lib/runners/qemu.nix
@@ -41,12 +41,10 @@ let
   qemuPkg =
     if microvmConfig.cpu == null && vmHostPackages.stdenv.hostPlatform.isLinux
     then
-      # If no CPU is requested and the host is Linux,
-      # use qemu with KVM support (hardware-accelerated)
+      # If no CPU is requested and the host is Linux, use qemu with KVM support (hardware-accelerated)
       vmHostPackages.qemu_kvm
     else
-      # Different CPU architectures like darwin or Non-Linux
-      # use the generic qemu package
+      # Different CPU architectures like darwin or Non-Linux use the generic qemu package
       vmHostPackages.qemu;
 
   qemu = overrideQemu qemuPkg;


### PR DESCRIPTION
Reintroduce conditional logic to select `qemu_kvm` for Linux hosts, while defaulting to `qemu` for other platforms.

Logic was removed https://github.com/microvm-nix/microvm.nix/commit/c034812a41da001e92e587965204cb0da698da72#diff-e281468e7547e8499c2ec97ce9d1b6c09fee9c518d20378bc7d7facc56d7e9b2L41-L50 

This will enable Linux Hosts to utilize `qemu_kvm` with additional advantages.