### PR TITLE
feat(writableStoreOverlay): make loading regInfo optional

### DIFF
--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -449,6 +449,14 @@ in
       description = "Whether to boot with the storeDisk, that is, unless the host's /nix/store is a microvm.share.";
     };
 
+    registerClosure = lib.mkEnableOption ''
+      Register system closure's store paths in Nix db.
+
+      While enabled by default, this option may be incompatible with a persistent writable store overlay.
+    '' // {
+      default = config.microvm.guest.enable;
+    };
+
     writableStoreOverlay = mkOption {
       type = with types; nullOr str;
       default = null;

--- a/nixos-modules/microvm/store-disk.nix
+++ b/nixos-modules/microvm/store-disk.nix
@@ -95,7 +95,7 @@ in
       '';
     })
 
-    (lib.mkIf (config.microvm.guest.enable && config.nix.enable) {
+    (lib.mkIf (config.microvm.registerClosure && config.nix.enable) {
       microvm.kernelParams = [
         "regInfo=${regInfo}/registration"
       ];


### PR DESCRIPTION
- Introduce `microvm.registerClosure` option.
- Gate `regInfo` kernel cmdline and `load-db` behind `registerClosure`.

This way, writableStoreOverlay may be (ab)used with a persistent Nix DB:
- If guest Nix encounters a store path present in the lowerdir, it'll have to realize it, i.e. write a copy to the upper dir. There's a chance we'll actually get a different copy (e.g. due to a different substitutor and/or non-deterministic builds), possibly leading to inconsistency.
  - Perhaps inconsistencies can be avoided by registering the ro-store as a "substitutor"?
- We can now swap the guest image, GC the Host's store, and reboot. This is tolerable, because system paths were never registered in the guest db, unless re-"realized" and copied to the upperdir.

This is not a pretty solution. E.g. when the Host store is mounted and the Guest reuses a store path from the Host, I'd maybe rather we dynamically create a gcroot on the Host, but that's extra complexity.