### PR TITLE
Add previously missing options to docs

### DIFF
--- a/pkgs/doc.nix
+++ b/pkgs/doc.nix
@@ -35,9 +35,9 @@ let
     };
   };
 
-  microvmDoc = makeOptionsDoc ../nixos-modules/microvm/options.nix;
+  microvmDoc = makeOptionsDoc ../nixos-modules/microvm/default.nix;
 
-  hostDoc = makeOptionsDoc ../nixos-modules/host/options.nix;
+  hostDoc = makeOptionsDoc ../nixos-modules/host/default.nix;
 
 in
 runCommand "microvm.nix-doc" {


### PR DESCRIPTION
Options like `microvm.vsock.ssh.enable` (guest) are currently missing from the generated HTML docs.

This is due to some options being defined in files that are imported by `default.nix`, but not `options.nix` (the entrypoint used to generate docs before this commit).

As `nixos-modules/microvm/default.nix` imports all the guest modules, I figured it would be best to generate docs from that instead.

This seems almost too easy... :laughing: 
