### PR TITLE
Wait for guest shutdown independently of stdin

### DIFF
--- a/lib/runners/qemu.nix
+++ b/lib/runners/qemu.nix
@@ -413,10 +413,17 @@ lib.warnIf (mem == 2048) ''
               };
             } ];
           }}
-           # wait for exit
-          cat
         ) | \
         ${vmHostPackages.socat}/bin/socat STDIO UNIX:${socket},shut-none
+
+        # Wait for the guest to actually shut down.
+        # Probing the socket instead of reading stdin makes the wait independent
+        # of how this script was invoked. QEMU stops accepting connections on the
+        # QMP socket once it exits, so a failing connect is the signal that it is
+        # gone.
+        while ${vmHostPackages.socat}/bin/socat -u /dev/null UNIX:${socket} 2>/dev/null; do
+          sleep 1
+        done
     ''
     else throw "Cannot shutdown without socket";
 


### PR DESCRIPTION
microvm-shutdown sends Ctrl+Alt+Del over QMP and then held the connection open with a bare `cat`, so that socat stayed connected until QEMU closed the QMP socket. That waits correctly from an interactive shell, but not from systemd.

systemd runs ExecStop with stdin on /dev/null, so `cat` read EOF immediately, socat exited, and microvm-shutdown returned about a second after sending the key event -- long before the guest had begun to stop. systemd then terminated QEMU (KillMode=control-group). Observed on a laptop host:

    Stopping MicroVM 'gui-vm'...
    gui-vm login: microvm@gui-vm: terminating on signal 15 from pid 1

one second apart, with no guest shutdown output at all.

The effect is that every microVM is killed rather than shut down: no guest unit runs its ExecStop and no guest filesystem is unmounted cleanly. It surfaced as display brightness never being remembered, because systemd-backlight saves its state in ExecStop and never got to run; any other state written at shutdown was lost the same way. The unit's TimeoutStopSec never applied, because nothing was left running for it to time out.

Probe the QMP socket instead of reading stdin, which makes the wait independent of how the script was invoked. QEMU stops accepting connections once it exits, so a failing connect is the signal that it is gone. The wait stays unbounded, as the `cat` was: under systemd TimeoutStopSec remains the backstop, and `microvm -s` behaves as before.