### PR TITLE
fix(crosvm): attach store disk as non-root

### DIFF
--- a/lib/runners/crosvm.nix
+++ b/lib/runners/crosvm.nix
@@ -74,7 +74,7 @@ in {
       )
       ++
       lib.optionals storeOnDisk [
-        "-r" storeDisk
+        "--block" "${storeDisk},ro=true"
       ]
       ++
       lib.optionals graphics.enable [


### PR DESCRIPTION
## What changed

Attach the generated store image to Crosvm with `--block <image>,ro=true` instead of `-r`.

## Why

Crosvm interprets `-r` as the guest root disk and appends `root=/dev/vda`. For `microvm.storeOnDisk`, the generated store image is a read-only Nix store input and must not replace the guest root filesystem.

Signed-off-by: vadik likholetov <vadikas@gmail.com>