### PR TITLE
fix(crosvm): Don't pull kernel.dev into resulting closure

### DIFF
--- a/lib/runners/crosvm.nix
+++ b/lib/runners/crosvm.nix
@@ -16,8 +16,14 @@ let
 
   crosvmPkg = microvmConfig.crosvm.package;
 
+  # Avoid pulling ${kernel.dev} and its dependencies into resulting closure
+  vmlinux = pkgs.runCommand "vmlinux" {} ''
+    mkdir -p $out
+    cp ${kernel.dev}/vmlinux $out/vmlinux
+  '';
+
   kernelPath = {
-    x86_64-linux = "${kernel.dev}/vmlinux";
+    x86_64-linux = "${vmlinux}/vmlinux";
     aarch64-linux = "${kernel.out}/${linuxTarget}";
   }.${system};
 


### PR DESCRIPTION
On x86_64-linux crosvm need uncompressed kernel, from kernel.dev, which pollute resulting closure with whole kernel.dev (~2GB), rustc (~1.5GB)  and binutils.

Create small package with copy single vmlinux file.