### PR TITLE
crosvm: Support protected PCI and native virtio-fs

### DIFF
--- a/checks/crosvm-platform.nix
+++ b/checks/crosvm-platform.nix
@@ -68,6 +68,79 @@ let
     linuxTarget = pkgs.linux.target or pkgs.stdenv.hostPlatform.linux-kernel.target;
   };
   assertionsPass = nixos: builtins.all ({ assertion, ... }: assertion) nixos.config.assertions;
+  protected = makeConfig [
+    {
+      nixpkgs.hostPlatform = "aarch64-linux";
+      microvm.crosvm.protection.mode = "protected-without-firmware";
+    }
+  ];
+  protectedRunner = import ../lib/runners/crosvm.nix {
+    inherit pkgs;
+    microvmConfig = protected.config.microvm;
+    macvtapFds = { };
+    linuxTarget = pkgs.linux.target or pkgs.stdenv.hostPlatform.linux-kernel.target;
+  };
+  protectedWithFirmware = makeConfig [
+    {
+      nixpkgs.hostPlatform = "aarch64-linux";
+      microvm.crosvm.protection = {
+        mode = "protected-with-firmware";
+        firmware = pkgs.writeText "test-pvmfw" "";
+      };
+    }
+  ];
+  protectedFirmwareRunner = import ../lib/runners/crosvm.nix {
+    inherit pkgs;
+    microvmConfig = protectedWithFirmware.config.microvm;
+    macvtapFds = { };
+    linuxTarget = pkgs.linux.target or pkgs.stdenv.hostPlatform.linux-kernel.target;
+  };
+  protectedWithAssignedDevice = makeConfig [
+    {
+      nixpkgs.hostPlatform = "aarch64-linux";
+      microvm = {
+        crosvm = {
+          deviceTreeOverlays = [ "mgbe0.dtbo" ];
+          protection = {
+            mode = "protected-without-firmware";
+            allowDeviceAssignment = true;
+          };
+        };
+        devices = [
+          {
+            bus = "platform";
+            path = "6800000.ethernet";
+            crosvm = {
+              dtSymbol = "mgbe0";
+              iommu = "pkvm-iommu";
+            };
+          }
+        ];
+      };
+    }
+  ];
+  protectedMissingFirmware = makeConfig [
+    {
+      nixpkgs.hostPlatform = "aarch64-linux";
+      microvm.crosvm.protection.mode = "protected-with-firmware";
+    }
+  ];
+  protectedWithShare = makeConfig [
+    {
+      nixpkgs.hostPlatform = "aarch64-linux";
+      microvm = {
+        crosvm.protection.mode = "protected-without-firmware";
+        shares = [
+          {
+            tag = "test-share";
+            source = "/tmp";
+            mountPoint = "/tmp/shared";
+            proto = "9p";
+          }
+        ];
+      };
+    }
+  ];
   missingSymbol = makeConfig [
     {
       microvm = {
@@ -131,16 +204,24 @@ lib.optionalAttrs (lib.hasSuffix "-linux" system) {
     assert lib.hasInfix "/sys/bus/pci/devices/0000:01:00.0,iommu=off,guest-address=00:1f.0" runner.command;
     assert lib.hasInfix "--mem 'size=512,base=0x2000000000'" layoutRunner.command;
     assert lib.hasInfix "--platform-mmio 'base=0x60000000,size=0x1fa0000000'" layoutRunner.command;
+    assert lib.hasInfix "--protected-vm-without-firmware --swiotlb 64" protectedRunner.command;
+    assert lib.hasInfix "--protected-vm-with-firmware" protectedFirmwareRunner.command;
+    assert !lib.hasInfix "--swiotlb" runner.command;
     assert lib.hasInfix (
       if pkgs.stdenv.hostPlatform.isAarch64 then "crosvm stop" else "crosvm powerbtn"
     ) runner.shutdownCommand;
     assert assertionsPass valid;
     assert assertionsPass layout;
+    assert assertionsPass protected;
+    assert assertionsPass protectedWithFirmware;
+    assert assertionsPass protectedWithAssignedDevice;
     assert !assertionsPass missingSymbol;
     assert !assertionsPass missingOverlay;
     assert !assertionsPass unsupportedHypervisor;
     assert !assertionsPass fixedPci;
     assert !assertionsPass unsupportedLayout;
     assert !assertionsPass overlappingLayout;
+    assert !assertionsPass protectedMissingFirmware;
+    assert !assertionsPass protectedWithShare;
     pkgs.runCommand "crosvm-platform-devices" { } "touch $out";
 }

--- a/checks/crosvm-platform.nix
+++ b/checks/crosvm-platform.nix
@@ -115,10 +115,24 @@ let
               iommu = "pkvm-iommu";
             };
           }
+          {
+            bus = "pci";
+            path = "0001:01:00.0";
+            crosvm = {
+              guestAddress = "00:1f.0";
+              iommu = "pkvm-iommu";
+            };
+          }
         ];
       };
     }
   ];
+  protectedAssignedRunner = import ../lib/runners/crosvm.nix {
+    inherit pkgs;
+    microvmConfig = protectedWithAssignedDevice.config.microvm;
+    macvtapFds = { };
+    linuxTarget = pkgs.linux.target or pkgs.stdenv.hostPlatform.linux-kernel.target;
+  };
   protectedMissingFirmware = makeConfig [
     {
       nixpkgs.hostPlatform = "aarch64-linux";
@@ -206,6 +220,8 @@ lib.optionalAttrs (lib.hasSuffix "-linux" system) {
     assert lib.hasInfix "--platform-mmio 'base=0x60000000,size=0x1fa0000000'" layoutRunner.command;
     assert lib.hasInfix "--protected-vm-without-firmware --swiotlb 64" protectedRunner.command;
     assert lib.hasInfix "--protected-vm-with-firmware" protectedFirmwareRunner.command;
+    assert lib.hasInfix "/sys/bus/platform/devices/6800000.ethernet,iommu=pkvm-iommu,dt-symbol=mgbe0" protectedAssignedRunner.command;
+    assert lib.hasInfix "/sys/bus/pci/devices/0001:01:00.0,iommu=pkvm-iommu,guest-address=00:1f.0" protectedAssignedRunner.command;
     assert !lib.hasInfix "--swiotlb" runner.command;
     assert lib.hasInfix (
       if pkgs.stdenv.hostPlatform.isAarch64 then "crosvm stop" else "crosvm powerbtn"

--- a/checks/crosvm-platform.nix
+++ b/checks/crosvm-platform.nix
@@ -155,6 +155,31 @@ let
       };
     }
   ];
+  protectedWithNativeVirtiofs = makeConfig [
+    {
+      nixpkgs.hostPlatform = "aarch64-linux";
+      microvm = {
+        crosvm = {
+          protection.mode = "protected-without-firmware";
+          virtiofsBackend = "crosvm";
+        };
+        shares = [
+          {
+            tag = "test-share";
+            source = "/tmp";
+            mountPoint = "/tmp/shared";
+            proto = "virtiofs";
+          }
+        ];
+      };
+    }
+  ];
+  protectedNativeVirtiofsRunner = import ../lib/runners/crosvm.nix {
+    inherit pkgs;
+    microvmConfig = protectedWithNativeVirtiofs.config.microvm;
+    macvtapFds = { };
+    linuxTarget = pkgs.linux.target or pkgs.stdenv.hostPlatform.linux-kernel.target;
+  };
   missingSymbol = makeConfig [
     {
       microvm = {
@@ -239,5 +264,10 @@ lib.optionalAttrs (lib.hasSuffix "-linux" system) {
     assert !assertionsPass overlappingLayout;
     assert !assertionsPass protectedMissingFirmware;
     assert !assertionsPass protectedWithShare;
+    assert assertionsPass protectedWithNativeVirtiofs;
+    assert lib.hasInfix "--shared-dir" protectedNativeVirtiofsRunner.command;
+    assert lib.hasInfix "/tmp:test-share:type=fs:cache=auto:dax=false:posix_acl=true" protectedNativeVirtiofsRunner.command;
+    assert !lib.hasInfix "--vhost-user type=fs" protectedNativeVirtiofsRunner.command;
+    assert !(protectedWithNativeVirtiofs.config.microvm.binScripts ? virtiofsd-run);
     pkgs.runCommand "crosvm-platform-devices" { } "touch $out";
 }

--- a/checks/crosvm-platform.nix
+++ b/checks/crosvm-platform.nix
@@ -1,0 +1,87 @@
+{ self, nixpkgs, system, ... }:
+
+let
+  inherit (nixpkgs) lib;
+  pkgs = nixpkgs.legacyPackages.${system};
+  makeConfig = modules: lib.nixosSystem {
+    inherit system;
+    modules = [
+      self.nixosModules.microvm
+      {
+        networking.hostName = "crosvm-platform-test";
+        system.stateVersion = "25.11";
+        microvm = {
+          hypervisor = "crosvm";
+          vsock.cid = 77;
+        };
+      }
+    ] ++ modules;
+  };
+  valid = makeConfig [
+    {
+      microvm = {
+        crosvm.deviceTreeOverlays = [ "overlay file.dtbo" ];
+        devices = [
+          {
+            bus = "platform";
+            path = "6800000.ethernet test";
+            crosvm.dtSymbol = "mgbe0";
+          }
+          {
+            bus = "pci";
+            path = "0000:01:00.0";
+            crosvm = {
+              guestAddress = "00:1f.0";
+              iommu = "off";
+            };
+          }
+        ];
+      };
+    }
+  ];
+  runner = import ../lib/runners/crosvm.nix {
+    inherit pkgs;
+    microvmConfig = valid.config.microvm;
+    macvtapFds = { };
+    linuxTarget = pkgs.linux.target or pkgs.stdenv.hostPlatform.linux-kernel.target;
+  };
+  assertionsPass = nixos: builtins.all ({ assertion, ... }: assertion) nixos.config.assertions;
+  missingSymbol = makeConfig [
+    {
+      microvm = {
+        crosvm.deviceTreeOverlays = [ "overlay.dtbo" ];
+        devices = [{ bus = "platform"; path = "6800000.ethernet"; }];
+      };
+    }
+  ];
+  missingOverlay = makeConfig [
+    {
+      microvm.devices = [
+        {
+          bus = "platform";
+          path = "6800000.ethernet";
+          crosvm.dtSymbol = "mgbe0";
+        }
+      ];
+    }
+  ];
+  unsupportedHypervisor = makeConfig [
+    {
+      microvm = {
+        hypervisor = lib.mkForce "qemu";
+        crosvm.deviceTreeOverlays = [ "overlay.dtbo" ];
+      };
+    }
+  ];
+in
+lib.optionalAttrs (lib.hasSuffix "-linux" system) {
+  crosvm-platform-devices =
+    assert lib.hasInfix "--device-tree-overlay 'overlay file.dtbo'" runner.command;
+    assert lib.hasInfix "'/sys/bus/platform/devices/6800000.ethernet test,iommu=off,dt-symbol=mgbe0'" runner.command;
+    assert lib.hasInfix "/sys/bus/pci/devices/0000:01:00.0,iommu=off,guest-address=00:1f.0" runner.command;
+    assert assertionsPass valid;
+    assert !assertionsPass missingSymbol;
+    assert !assertionsPass missingOverlay;
+    assert !assertionsPass unsupportedHypervisor;
+    pkgs.runCommand "crosvm-platform-devices" { } "touch $out";
+}

--- a/checks/crosvm-platform.nix
+++ b/checks/crosvm-platform.nix
@@ -131,6 +131,9 @@ lib.optionalAttrs (lib.hasSuffix "-linux" system) {
     assert lib.hasInfix "/sys/bus/pci/devices/0000:01:00.0,iommu=off,guest-address=00:1f.0" runner.command;
     assert lib.hasInfix "--mem 'size=512,base=0x2000000000'" layoutRunner.command;
     assert lib.hasInfix "--platform-mmio 'base=0x60000000,size=0x1fa0000000'" layoutRunner.command;
+    assert lib.hasInfix (
+      if pkgs.stdenv.hostPlatform.isAarch64 then "crosvm stop" else "crosvm powerbtn"
+    ) runner.shutdownCommand;
     assert assertionsPass valid;
     assert assertionsPass layout;
     assert !assertionsPass missingSymbol;

--- a/checks/crosvm-platform.nix
+++ b/checks/crosvm-platform.nix
@@ -25,7 +25,11 @@ let
           {
             bus = "platform";
             path = "6800000.ethernet test";
-            crosvm.dtSymbol = "mgbe0";
+            crosvm = {
+              dtSymbol = "mgbe0";
+              mmioBase = 1711276032;
+              mapEarly = true;
+            };
           }
           {
             bus = "pci";
@@ -42,6 +46,24 @@ let
   runner = import ../lib/runners/crosvm.nix {
     inherit pkgs;
     microvmConfig = valid.config.microvm;
+    macvtapFds = { };
+    linuxTarget = pkgs.linux.target or pkgs.stdenv.hostPlatform.linux-kernel.target;
+  };
+  layout = makeConfig [
+    {
+      nixpkgs.hostPlatform = "aarch64-linux";
+      microvm.crosvm = {
+        memoryBase = 137438953472;
+        platformMmio = {
+          base = 1610612736;
+          size = 135828340736;
+        };
+      };
+    }
+  ];
+  layoutRunner = import ../lib/runners/crosvm.nix {
+    inherit pkgs;
+    microvmConfig = layout.config.microvm;
     macvtapFds = { };
     linuxTarget = pkgs.linux.target or pkgs.stdenv.hostPlatform.linux-kernel.target;
   };
@@ -73,15 +95,49 @@ let
       };
     }
   ];
+  fixedPci = makeConfig [
+    {
+      microvm.devices = [
+        {
+          bus = "pci";
+          path = "0000:01:00.0";
+          crosvm.mmioBase = 1711276032;
+        }
+      ];
+    }
+  ];
+  unsupportedLayout = makeConfig [
+    {
+      microvm.crosvm.memoryBase = 137438953472;
+    }
+  ];
+  overlappingLayout = makeConfig [
+    {
+      nixpkgs.hostPlatform = "aarch64-linux";
+      microvm.crosvm = {
+        memoryBase = 2147483648;
+        platformMmio = {
+          base = 2415919104;
+          size = 268435456;
+        };
+      };
+    }
+  ];
 in
 lib.optionalAttrs (lib.hasSuffix "-linux" system) {
   crosvm-platform-devices =
     assert lib.hasInfix "--device-tree-overlay 'overlay file.dtbo'" runner.command;
-    assert lib.hasInfix "'/sys/bus/platform/devices/6800000.ethernet test,iommu=off,dt-symbol=mgbe0'" runner.command;
+    assert lib.hasInfix "'/sys/bus/platform/devices/6800000.ethernet test,iommu=off,dt-symbol=mgbe0,mmio-base=0x66000000,map-early=true'" runner.command;
     assert lib.hasInfix "/sys/bus/pci/devices/0000:01:00.0,iommu=off,guest-address=00:1f.0" runner.command;
+    assert lib.hasInfix "--mem 'size=512,base=0x2000000000'" layoutRunner.command;
+    assert lib.hasInfix "--platform-mmio 'base=0x60000000,size=0x1fa0000000'" layoutRunner.command;
     assert assertionsPass valid;
+    assert assertionsPass layout;
     assert !assertionsPass missingSymbol;
     assert !assertionsPass missingOverlay;
     assert !assertionsPass unsupportedHypervisor;
+    assert !assertionsPass fixedPci;
+    assert !assertionsPass unsupportedLayout;
+    assert !assertionsPass overlappingLayout;
     pkgs.runCommand "crosvm-platform-devices" { } "touch $out";
 }

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -252,6 +252,7 @@ let
 in
 import ./shellcheck.nix args //
 import ./microvm-command.nix args //
+import ./crosvm-platform.nix args //
 import ./imperative-template.nix args //
 import ./startup-shutdown.nix args //
 import ./shutdown-command.nix args //

--- a/lib/runners/crosvm.nix
+++ b/lib/runners/crosvm.nix
@@ -13,7 +13,7 @@ let
     socket devices vsock graphics credentialFiles
     kernel initrdPath storeDisk storeOnDisk;
   inherit (microvmConfig.crosvm)
-    pivotRoot extraArgs deviceTreeOverlays memoryBase platformMmio protection;
+    pivotRoot extraArgs deviceTreeOverlays memoryBase platformMmio protection virtiofsBackend;
 
   crosvmPkg = microvmConfig.crosvm.package;
   isProtected = protection.mode != "unprotected";
@@ -136,10 +136,16 @@ in {
         ]
       ) volumes
       ++
-      builtins.concatMap ({ proto, tag, source, socket, readOnly, ... }: {
-        "virtiofs" = [
-          "--vhost-user" "type=fs,socket=${socket}"
-        ];
+      builtins.concatMap ({ proto, tag, source, socket, readOnly, cache, posixAcl, ... }: {
+        "virtiofs" =
+          if virtiofsBackend == "crosvm"
+          then [
+            "--shared-dir"
+            "${source}:${tag}:type=fs:cache=${cache}:dax=false:posix_acl=${lib.boolToString posixAcl}"
+          ]
+          else [
+            "--vhost-user" "type=fs,socket=${socket}"
+          ];
         "9p" = if readOnly then
           throw "Readonly 9p share is not supported"
         else [

--- a/lib/runners/crosvm.nix
+++ b/lib/runners/crosvm.nix
@@ -12,7 +12,7 @@ let
     vcpu mem balloon initialBalloonMem hotplugMem hotpluggedMem user volumes shares
     socket devices vsock graphics credentialFiles
     kernel initrdPath storeDisk storeOnDisk;
-  inherit (microvmConfig.crosvm) pivotRoot extraArgs;
+  inherit (microvmConfig.crosvm) pivotRoot extraArgs deviceTreeOverlays;
 
   crosvmPkg = microvmConfig.crosvm.package;
 
@@ -32,6 +32,15 @@ let
     egl = true;
     vulkan = true;
   };
+
+  vfioDeviceArgs = { bus, path, crosvm, ... }: [
+    "--vfio"
+    ({
+      pci = "/sys/bus/pci/devices/${path},iommu=${crosvm.iommu}${lib.optionalString (crosvm.guestAddress != null) ",guest-address=${crosvm.guestAddress}"}${lib.optionalString (crosvm.dtSymbol != null) ",dt-symbol=${crosvm.dtSymbol}"}";
+      platform = "/sys/bus/platform/devices/${path},iommu=${crosvm.iommu},dt-symbol=${crosvm.dtSymbol}";
+      usb = throw "USB passthrough is not supported on crosvm";
+    }.${bus})
+  ];
 
 in {
 
@@ -142,16 +151,17 @@ in {
         "--vsock" (toString vsock.cid)
       ]
       ++
+      builtins.concatMap (overlay: [
+        "--device-tree-overlay" overlay
+      ]) deviceTreeOverlays
+      ++
       [
         "--initrd" initrdPath
         kernelPath
       ]
     )
-    + " " + # Move vfio-pci outside of
-      lib.concatStringsSep " " (lib.concatMap ({ bus, path, ... }: {
-        pci = [ "--vfio" "/sys/bus/pci/devices/${path},iommu=viommu" ];
-        usb = throw "USB passthrough is not supported on crosvm";
-      }.${bus}) devices)
+    + " " + # Keep host device paths outside of the Nix store.
+      lib.escapeShellArgs (lib.concatMap vfioDeviceArgs devices)
     + " " + lib.escapeShellArgs extraArgs;
 
   canShutdown = socket != null;

--- a/lib/runners/crosvm.nix
+++ b/lib/runners/crosvm.nix
@@ -178,7 +178,7 @@ in {
   shutdownCommand =
     if socket != null
     then ''
-        ${crosvmPkg}/bin/crosvm powerbtn ${socket}
+        ${crosvmPkg}/bin/crosvm ${if pkgs.stdenv.hostPlatform.isAarch64 then "stop" else "powerbtn"} ${socket}
       ''
     else throw "Cannot shutdown without socket";
 

--- a/lib/runners/crosvm.nix
+++ b/lib/runners/crosvm.nix
@@ -13,9 +13,24 @@ let
     socket devices vsock graphics credentialFiles
     kernel initrdPath storeDisk storeOnDisk;
   inherit (microvmConfig.crosvm)
-    pivotRoot extraArgs deviceTreeOverlays memoryBase platformMmio;
+    pivotRoot extraArgs deviceTreeOverlays memoryBase platformMmio protection;
 
   crosvmPkg = microvmConfig.crosvm.package;
+  isProtected = protection.mode != "unprotected";
+  protectionArgs =
+    {
+      unprotected = [ ];
+      protected-without-firmware = [ "--protected-vm-without-firmware" ];
+      protected-with-firmware = [
+        "--protected-vm-with-firmware"
+        (toString protection.firmware)
+      ];
+    }
+    .${protection.mode}
+    ++ lib.optionals isProtected [
+      "--swiotlb"
+      (toString (if protection.swiotlbSizeMiB == null then 64 else protection.swiotlbSizeMiB))
+    ];
 
   # Avoid pulling ${kernel.dev} and its dependencies into resulting closure
   vmlinux = pkgs.runCommand "vmlinux" {} ''
@@ -163,6 +178,8 @@ in {
       builtins.concatMap (overlay: [
         "--device-tree-overlay" overlay
       ]) deviceTreeOverlays
+      ++
+      protectionArgs
       ++
       [
         "--initrd" initrdPath

--- a/lib/runners/crosvm.nix
+++ b/lib/runners/crosvm.nix
@@ -12,7 +12,8 @@ let
     vcpu mem balloon initialBalloonMem hotplugMem hotpluggedMem user volumes shares
     socket devices vsock graphics credentialFiles
     kernel initrdPath storeDisk storeOnDisk;
-  inherit (microvmConfig.crosvm) pivotRoot extraArgs deviceTreeOverlays;
+  inherit (microvmConfig.crosvm)
+    pivotRoot extraArgs deviceTreeOverlays memoryBase platformMmio;
 
   crosvmPkg = microvmConfig.crosvm.package;
 
@@ -33,11 +34,13 @@ let
     vulkan = true;
   };
 
+  formatAddress = value: "0x${lib.toLower (lib.toHexString value)}";
+
   vfioDeviceArgs = { bus, path, crosvm, ... }: [
     "--vfio"
     ({
       pci = "/sys/bus/pci/devices/${path},iommu=${crosvm.iommu}${lib.optionalString (crosvm.guestAddress != null) ",guest-address=${crosvm.guestAddress}"}${lib.optionalString (crosvm.dtSymbol != null) ",dt-symbol=${crosvm.dtSymbol}"}";
-      platform = "/sys/bus/platform/devices/${path},iommu=${crosvm.iommu},dt-symbol=${crosvm.dtSymbol}";
+      platform = "/sys/bus/platform/devices/${path},iommu=${crosvm.iommu},dt-symbol=${crosvm.dtSymbol}${lib.optionalString (crosvm.mmioBase != null) ",mmio-base=${formatAddress crosvm.mmioBase}"}${lib.optionalString crosvm.mapEarly ",map-early=true"}";
       usb = throw "USB passthrough is not supported on crosvm";
     }.${bus})
   ];
@@ -76,7 +79,8 @@ in {
     else lib.escapeShellArgs (
       [
         "${crosvmPkg}/bin/crosvm" "run"
-        "-m" (toString mem)
+        (if memoryBase == null then "-m" else "--mem")
+        (if memoryBase == null then toString mem else "size=${toString mem},base=${formatAddress memoryBase}")
         "-c" (toString vcpu)
         "--serial" "type=stdout,console=true,stdin=true"
         "-p" "console=ttyS0 reboot=k panic=1 ${toString microvmConfig.kernelParams}"
@@ -149,6 +153,11 @@ in {
       ++
       lib.optionals (vsock.cid != null) [
         "--vsock" (toString vsock.cid)
+      ]
+      ++
+      lib.optionals (platformMmio != null) [
+        "--platform-mmio"
+        "base=${formatAddress platformMmio.base},size=${formatAddress platformMmio.size}"
       ]
       ++
       builtins.concatMap (overlay: [

--- a/nixos-modules/microvm/asserts.nix
+++ b/nixos-modules/microvm/asserts.nix
@@ -1,6 +1,15 @@
-{ config, lib, ... }:
+{ config, lib, pkgs, ... }:
 let
   inherit (config.networking) hostName;
+  crosvmLayoutEnabled =
+    config.microvm.crosvm.memoryBase != null
+    || config.microvm.crosvm.platformMmio != null;
+  memoryEnd =
+    if config.microvm.crosvm.memoryBase == null then null
+    else config.microvm.crosvm.memoryBase + config.microvm.mem * 1024 * 1024;
+  platformMmioEnd =
+    if config.microvm.crosvm.platformMmio == null then null
+    else config.microvm.crosvm.platformMmio.base + config.microvm.crosvm.platformMmio.size;
 
 in
 lib.mkIf config.microvm.guest.enable {
@@ -128,6 +137,13 @@ lib.mkIf config.microvm.guest.enable {
       '';
     }) (builtins.filter ({ bus, ... }: bus == "platform") config.microvm.devices)
     ++
+    map ({ path, bus, crosvm, ... }: {
+      assertion = (crosvm.mmioBase == null && !crosvm.mapEarly) || bus == "platform";
+      message = ''
+        MicroVM ${hostName}: Crosvm fixed/early mapping for device "${path}" is only supported on the platform bus.
+      '';
+    }) config.microvm.devices
+    ++
     [
       {
         assertion =
@@ -143,6 +159,27 @@ lib.mkIf config.microvm.guest.enable {
           || config.microvm.hypervisor == "crosvm";
         message = ''
           MicroVM ${hostName}: `microvm.crosvm.deviceTreeOverlays` is only supported with Crosvm.
+        '';
+      }
+      {
+        assertion =
+          !crosvmLayoutEnabled
+          || (
+            config.microvm.hypervisor == "crosvm"
+            && pkgs.stdenv.hostPlatform.system == "aarch64-linux"
+          );
+        message = ''
+          MicroVM ${hostName}: explicit Crosvm RAM/platform MMIO layout requires AArch64 and the crosvm hypervisor.
+        '';
+      }
+      {
+        assertion =
+          memoryEnd == null
+          || platformMmioEnd == null
+          || memoryEnd <= config.microvm.crosvm.platformMmio.base
+          || platformMmioEnd <= config.microvm.crosvm.memoryBase;
+        message = ''
+          MicroVM ${hostName}: Crosvm RAM and platform MMIO ranges overlap.
         '';
       }
     ]

--- a/nixos-modules/microvm/asserts.nix
+++ b/nixos-modules/microvm/asserts.nix
@@ -236,8 +236,8 @@ lib.mkIf config.microvm.guest.enable {
       {
         assertion =
           !protection.allowDeviceAssignment
-          || lib.all ({ bus, ... }: bus == "platform") config.microvm.devices;
-        message = "Protected device assignment currently supports platform devices only.";
+          || lib.all ({ bus, ... }: lib.elem bus [ "platform" "pci" ]) config.microvm.devices;
+        message = "Protected device assignment supports static platform and PCI devices only.";
       }
       {
         assertion = !isProtected || config.microvm.devices == [ ] || protection.allowDeviceAssignment;

--- a/nixos-modules/microvm/asserts.nix
+++ b/nixos-modules/microvm/asserts.nix
@@ -12,6 +12,10 @@ let
     else config.microvm.crosvm.platformMmio.base + config.microvm.crosvm.platformMmio.size;
   protection = config.microvm.crosvm.protection;
   isProtected = protection.mode != "unprotected";
+  usesNativeCrosvmVirtiofs =
+    config.microvm.hypervisor == "crosvm"
+    && config.microvm.crosvm.virtiofsBackend == "crosvm";
+  virtiofsShares = builtins.filter ({ proto, ... }: proto == "virtiofs") config.microvm.shares;
   rawProtectionArgs = [
     "--protected-vm"
     "--protected-vm-with-firmware"
@@ -220,8 +224,38 @@ lib.mkIf config.microvm.guest.enable {
         message = "Crosvm protected MicroVMs do not support ballooning.";
       }
       {
-        assertion = !isProtected || config.microvm.shares == [ ];
-        message = "Crosvm protected MicroVMs cannot use host shared-directory backends.";
+        assertion =
+          !isProtected
+          || config.microvm.shares == [ ]
+          || (
+            usesNativeCrosvmVirtiofs
+            && builtins.length virtiofsShares == builtins.length config.microvm.shares
+          );
+        message = "Crosvm protected MicroVMs support only native Crosvm virtio-fs shares.";
+      }
+      {
+        assertion =
+          config.microvm.crosvm.virtiofsBackend == "vhost-user"
+          || config.microvm.hypervisor == "crosvm";
+        message = "The native Crosvm virtio-fs backend requires the crosvm hypervisor.";
+      }
+      {
+        assertion =
+          !usesNativeCrosvmVirtiofs
+          || lib.all ({ readOnly, ... }: !readOnly) virtiofsShares;
+        message = "The native Crosvm virtio-fs backend does not support read-only shares.";
+      }
+      {
+        assertion =
+          !usesNativeCrosvmVirtiofs
+          || lib.all ({ cache, ... }: cache != "metadata") virtiofsShares;
+        message = "The native Crosvm virtio-fs backend does not support metadata-only caching.";
+      }
+      {
+        assertion =
+          !usesNativeCrosvmVirtiofs
+          || lib.all ({ extraArgs, ... }: extraArgs == [ ]) virtiofsShares;
+        message = "The native Crosvm virtio-fs backend does not accept virtiofsd arguments.";
       }
       {
         assertion = !protection.allowDeviceAssignment || isProtected;

--- a/nixos-modules/microvm/asserts.nix
+++ b/nixos-modules/microvm/asserts.nix
@@ -10,6 +10,15 @@ let
   platformMmioEnd =
     if config.microvm.crosvm.platformMmio == null then null
     else config.microvm.crosvm.platformMmio.base + config.microvm.crosvm.platformMmio.size;
+  protection = config.microvm.crosvm.protection;
+  isProtected = protection.mode != "unprotected";
+  rawProtectionArgs = [
+    "--protected-vm"
+    "--protected-vm-with-firmware"
+    "--protected-vm-without-firmware"
+    "--swiotlb"
+    "--unprotected-vm-with-firmware"
+  ];
 
 in
 lib.mkIf config.microvm.guest.enable {
@@ -181,6 +190,62 @@ lib.mkIf config.microvm.guest.enable {
         message = ''
           MicroVM ${hostName}: Crosvm RAM and platform MMIO ranges overlap.
         '';
+      }
+      {
+        assertion = lib.all (arg: !builtins.elem arg config.microvm.crosvm.extraArgs) rawProtectionArgs;
+        message = "Use `microvm.crosvm.protection` instead of raw Crosvm protection arguments.";
+      }
+      {
+        assertion = !isProtected || config.microvm.hypervisor == "crosvm";
+        message = "Protected MicroVMs require the crosvm hypervisor.";
+      }
+      {
+        assertion = !isProtected || pkgs.stdenv.hostPlatform.system == "aarch64-linux";
+        message = "Crosvm protected MicroVMs are currently supported only on AArch64 Linux.";
+      }
+      {
+        assertion = protection.mode == "protected-with-firmware" || protection.firmware == null;
+        message = "`microvm.crosvm.protection.firmware` requires protected-with-firmware mode.";
+      }
+      {
+        assertion = protection.mode != "protected-with-firmware" || protection.firmware != null;
+        message = "protected-with-firmware mode requires `microvm.crosvm.protection.firmware`.";
+      }
+      {
+        assertion = isProtected || protection.swiotlbSizeMiB == null;
+        message = "`microvm.crosvm.protection.swiotlbSizeMiB` requires a protected mode.";
+      }
+      {
+        assertion = !isProtected || !config.microvm.balloon;
+        message = "Crosvm protected MicroVMs do not support ballooning.";
+      }
+      {
+        assertion = !isProtected || config.microvm.shares == [ ];
+        message = "Crosvm protected MicroVMs cannot use host shared-directory backends.";
+      }
+      {
+        assertion = !protection.allowDeviceAssignment || isProtected;
+        message = "Protected device assignment requires a protected Crosvm mode.";
+      }
+      {
+        assertion =
+          !protection.allowDeviceAssignment
+          || lib.all ({ crosvm, ... }: crosvm.iommu == "pkvm-iommu") config.microvm.devices;
+        message = "Protected device assignment requires `iommu = \"pkvm-iommu\"` for every assigned device.";
+      }
+      {
+        assertion =
+          !protection.allowDeviceAssignment
+          || lib.all ({ bus, ... }: bus == "platform") config.microvm.devices;
+        message = "Protected device assignment currently supports platform devices only.";
+      }
+      {
+        assertion = !isProtected || config.microvm.devices == [ ] || protection.allowDeviceAssignment;
+        message = "Crosvm protected MicroVM device assignment requires an explicit backend opt-in.";
+      }
+      {
+        assertion = !isProtected || !config.microvm.graphics.enable;
+        message = "Crosvm protected MicroVMs cannot use the host graphics backend.";
       }
     ]
     ++

--- a/nixos-modules/microvm/asserts.nix
+++ b/nixos-modules/microvm/asserts.nix
@@ -114,6 +114,39 @@ lib.mkIf config.microvm.guest.enable {
         config.microvm.shares
     )
     ++
+    map ({ path, ... }: {
+      assertion = config.microvm.hypervisor == "crosvm";
+      message = ''
+        MicroVM ${hostName}: platform device "${path}" is only supported with Crosvm.
+      '';
+    }) (builtins.filter ({ bus, ... }: bus == "platform") config.microvm.devices)
+    ++
+    map ({ path, crosvm, ... }: {
+      assertion = crosvm.dtSymbol != null;
+      message = ''
+        MicroVM ${hostName}: platform device "${path}" requires `crosvm.dtSymbol`.
+      '';
+    }) (builtins.filter ({ bus, ... }: bus == "platform") config.microvm.devices)
+    ++
+    [
+      {
+        assertion =
+          !(builtins.any ({ bus, ... }: bus == "platform") config.microvm.devices)
+          || config.microvm.crosvm.deviceTreeOverlays != [];
+        message = ''
+          MicroVM ${hostName}: platform devices require a `microvm.crosvm.deviceTreeOverlays` entry.
+        '';
+      }
+      {
+        assertion =
+          config.microvm.crosvm.deviceTreeOverlays == []
+          || config.microvm.hypervisor == "crosvm";
+        message = ''
+          MicroVM ${hostName}: `microvm.crosvm.deviceTreeOverlays` is only supported with Crosvm.
+        '';
+      }
+    ]
+    ++
     # blacklist forwardPorts
     [ {
       assertion =

--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -434,7 +434,7 @@ in
     };
 
     devices = mkOption {
-      description = "PCI/USB devices that are passed from the host to the MicroVM";
+      description = "PCI/platform/USB devices that are passed from the host to the MicroVM";
       default = [];
       example = literalExpression /* nix */ ''
         [ {
@@ -450,12 +450,12 @@ in
           path = "vendorid=0xabcd,productid=0x0123";
         } ]
       '';
-      type = with types; listOf (submodule {
+      type = with types; listOf (submodule ({ config, ... }: {
         options = {
           bus = mkOption {
-            type = enum [ "pci" "usb" ];
+            type = enum [ "pci" "platform" "usb" ];
             description = ''
-              Device is either on the `pci` or the `usb` bus
+              Bus that identifies the host device.
             '';
           };
           path = mkOption {
@@ -487,8 +487,26 @@ in
               '';
             };
           };
+          crosvm = {
+            dtSymbol = mkOption {
+              type = nullOr str;
+              default = null;
+              description = "Device-tree symbol assigned to this device.";
+            };
+            guestAddress = mkOption {
+              type = nullOr str;
+              default = null;
+              description = "PCI address assigned to this device in the guest.";
+            };
+            iommu = mkOption {
+              type = enum [ "off" "viommu" "coiommu" "pkvm-iommu" ];
+              default = if config.bus == "platform" then "off" else "viommu";
+              defaultText = literalExpression ''if config.bus == "platform" then "off" else "viommu"'';
+              description = "Crosvm IOMMU mode for this device.";
+            };
+          };
         };
-      });
+      }));
     };
 
     vsock.cid = mkOption {
@@ -816,6 +834,12 @@ in
       type = with types; listOf str;
       default = [];
       description = "Extra arguments to pass to crosvm.";
+    };
+
+    crosvm.deviceTreeOverlays = mkOption {
+      type = with types; listOf str;
+      default = [];
+      description = "Device-tree overlay filenames passed to Crosvm.";
     };
 
     crosvm.pivotRoot = mkOption {

--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -875,6 +875,43 @@ in
       description = "Explicit Crosvm platform MMIO aperture.";
     };
 
+    crosvm.protection = {
+      mode = mkOption {
+        type = types.enum [
+          "unprotected"
+          "protected-without-firmware"
+          "protected-with-firmware"
+        ];
+        default = "unprotected";
+        description = "Crosvm guest-memory protection mode.";
+      };
+
+      firmware = mkOption {
+        type = with types; nullOr path;
+        default = null;
+        description = "Custom firmware used by protected-with-firmware mode.";
+      };
+
+      swiotlbSizeMiB = mkOption {
+        type = with types; nullOr ints.positive;
+        default = null;
+        description = ''
+          Size in MiB of the protected guest's static SWIOTLB restricted DMA
+          pool. Protected guests use Crosvm's 64 MiB default when this is null.
+        '';
+      };
+
+      allowDeviceAssignment = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Allow platform devices using Crosvm's pKVM IOMMU path in this
+          protected guest. This requires a host backend that implements
+          protected device assignment and reset.
+        '';
+      };
+    };
+
     crosvm.pivotRoot = mkOption {
       type = with types; nullOr str;
       default = null;

--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -846,6 +846,19 @@ in
       description = "Extra arguments to pass to crosvm.";
     };
 
+    crosvm.virtiofsBackend = mkOption {
+      type = types.enum [
+        "vhost-user"
+        "crosvm"
+      ];
+      default = "vhost-user";
+      description = ''
+        Backend used for virtio-fs shares. The vhost-user backend starts an
+        external virtiofsd process. The crosvm backend uses Crosvm's native
+        virtio-fs device without DAX and does not start virtiofsd.
+      '';
+    };
+
     crosvm.deviceTreeOverlays = mkOption {
       type = with types; listOf str;
       default = [];

--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -905,9 +905,9 @@ in
         type = types.bool;
         default = false;
         description = ''
-          Allow platform devices using Crosvm's pKVM IOMMU path in this
-          protected guest. This requires a host backend that implements
-          protected device assignment and reset.
+          Allow static platform and PCI devices using Crosvm's pKVM IOMMU
+          path in this protected guest. This requires a host backend that
+          implements protected device assignment and reset for every device.
         '';
       };
     };

--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -504,6 +504,16 @@ in
               defaultText = literalExpression ''if config.bus == "platform" then "off" else "viommu"'';
               description = "Crosvm IOMMU mode for this device.";
             };
+            mmioBase = mkOption {
+              type = nullOr ints.unsigned;
+              default = null;
+              description = "Exact guest physical address for a single-region Crosvm platform device.";
+            };
+            mapEarly = mkOption {
+              type = bool;
+              default = false;
+              description = "Map this Crosvm platform device before guest execution starts.";
+            };
           };
         };
       }));
@@ -840,6 +850,29 @@ in
       type = with types; listOf str;
       default = [];
       description = "Device-tree overlay filenames passed to Crosvm.";
+    };
+
+    crosvm.memoryBase = mkOption {
+      type = with types; nullOr ints.unsigned;
+      default = null;
+      description = "Base guest physical address of Crosvm RAM.";
+    };
+
+    crosvm.platformMmio = mkOption {
+      type = with types; nullOr (submodule {
+        options = {
+          base = mkOption {
+            type = ints.unsigned;
+            description = "Base guest physical address of the Crosvm platform MMIO aperture.";
+          };
+          size = mkOption {
+            type = ints.positive;
+            description = "Size in bytes of the Crosvm platform MMIO aperture.";
+          };
+        };
+      });
+      default = null;
+      description = "Explicit Crosvm platform MMIO aperture.";
     };
 
     crosvm.pivotRoot = mkOption {

--- a/nixos-modules/microvm/virtiofsd/default.nix
+++ b/nixos-modules/microvm/virtiofsd/default.nix
@@ -5,7 +5,13 @@ let
     proto == "virtiofs"
   ) config.microvm.shares;
 
-  requiresVirtiofsd = virtiofsShares != [] && config.microvm.hypervisor != "vfkit";
+  requiresVirtiofsd =
+    virtiofsShares != []
+    && config.microvm.hypervisor != "vfkit"
+    && !(
+      config.microvm.hypervisor == "crosvm"
+      && config.microvm.crosvm.virtiofsBackend == "crosvm"
+    );
 
   inherit (pkgs.python3Packages) supervisor;
   supervisord = lib.getExe' supervisor "supervisord";


### PR DESCRIPTION
## Summary

Extend the protected Crosvm interfaces from #586 with two explicitly opted-in capabilities:

- static PCI assignment alongside platform devices, retaining the `pkvm-iommu` requirement for every protected assignment;
- Crosvm-native virtio-fs as an alternative to exporting guest memory to an external vhost-user `virtiofsd` process.

This draft is stacked on microvm.nix #586. Until #586 merges, the combined GitHub diff includes that provider series.

## Commits

- `157c287703f1`: allow protected static PCI assignment.
- `37184b96454b`: add the native Crosvm virtio-fs backend.

## Native Virtio-fs Boundary

The new `microvm.crosvm.virtiofsBackend = "crosvm"` mode emits Crosvm `--shared-dir ...:type=fs:dax=false` arguments and does not generate a `virtiofsd-run` launcher. Protected guests may use only virtio-fs shares through this backend.

The module rejects read-only shares, metadata-only caching, virtiofsd-specific arguments, 9p shares, and use under a non-Crosvm hypervisor. Existing guests retain the vhost-user backend by default.

## Verification

- Rebased onto upstream `main` at `804cbac7a462aa0fa8bb60c3d2fc4ead0a62060f`; the range-diff preserves all six logical commits, with only the protected-interface commit adapted to current closure-safe `vmlinux` handling.
- `checks.x86_64-linux.crosvm-platform-devices` passes.
- The generated protected runner contains native non-DAX `--shared-dir` and no vhost-user filesystem backend.
- The generated protected configuration contains no `virtiofsd-run` script.
- The prior exact-pin Ghaf AGX image, protected RTL8822CE traffic, active teardown, and three settled NetVM cycles remain the PCI-assignment evidence.

Hardware validation of the new protected virtio-fs path is tracked in Ghaf #2190 and is not claimed by this PR yet.
