### PR TITLE
feat(host): make installing the microvm CLI optional

### DIFF
--- a/nixos-modules/host/default.nix
+++ b/nixos-modules/host/default.nix
@@ -74,7 +74,7 @@ in
         }
         (builtins.attrNames config.microvm.vms);
 
-    environment.systemPackages = [
+    environment.systemPackages = lib.optionals config.microvm.host.installCommand [
       microvmCommand
     ];
 

--- a/nixos-modules/host/options.nix
+++ b/nixos-modules/host/options.nix
@@ -9,6 +9,20 @@
         Whether to enable the microvm.nix host module.
       '';
     };
+    host.installCommand = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Whether to install the `microvm` management CLI into
+        `environment.systemPackages` on the host.
+
+        It shells out to `nix` to create/update/run VMs from a flake, so it
+        makes the Nix binary a runtime dependency of the host closure. Set to
+        false on appliance-style images that manage guests purely through the
+        generated `microvm@.service` units and must not ship Nix.
+      '';
+    };
+
     host.startupTimeout = mkOption {
       description = "Start up timeout for the VMs in seconds";
       type = types.ints.positive;


### PR DESCRIPTION
microvmCommand bakes nix into its PATH, so importing nixosModules.host puts the Nix binary in every host closure even when guests are managed purely through the generated microvm@.service units. Defaults to true, unchanged.