### PR TITLE
feat: open the store disk with O_DIRECT where the hypervisor supports it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@
   results in a much faster build for a slightly larger image.
   `-Efragments` is kept as it is compatible with multi-threading. Add
   `-Ededupe` back to favor small image size over build speed.
+* The store disk is now opened with O_DIRECT on crosvm, qemu,
+  cloud-hypervisor, kvmtool, and stratovirt to avoid double caching
+  in both the host and the guest. Set the new
+  `microvm.storeDiskDirect = false` to restore buffered reads.
+  Enabling it on an unsupported VMM is an error.
 
 ## 0.5.0 (2024-04-06)
 

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -13,6 +13,15 @@ rec {
 
   hypervisorsWithNetwork = hypervisors;
 
+  # Hypervisors whose store disk argument accepts a direct I/O flag
+  hypervisorsWithStoreDiskDirect = [
+    "qemu"
+    "cloud-hypervisor"
+    "crosvm"
+    "kvmtool"
+    "stratovirt"
+  ];
+
   defaultFsType = "ext4";
 
   withDriveLetters = { volumes, storeOnDisk, ... }:

--- a/lib/runners/alioth.nix
+++ b/lib/runners/alioth.nix
@@ -13,7 +13,7 @@ let
     user
     vcpu mem balloon initialBalloonMem hotplugMem hotpluggedMem interfaces volumes shares devices vsock
     kernel initrdPath
-    storeDisk storeOnDisk credentialFiles;
+    storeDisk storeOnDisk storeDiskDirect credentialFiles;
 in {
   command =
     if user != null
@@ -28,6 +28,8 @@ in {
     then throw "alioth does not support hotpluggedMem"
     else if credentialFiles != {}
     then throw "alioth does not support credentialFiles"
+    else if storeDiskDirect
+    then throw "alioth does not support storeDiskDirect"
     else builtins.concatStringsSep " " (
       [
         "${aliothPkg}/bin/alioth" "run"

--- a/lib/runners/cloud-hypervisor.nix
+++ b/lib/runners/cloud-hypervisor.nix
@@ -9,7 +9,7 @@
 
 let
   inherit (pkgs) lib;
-  inherit (microvmConfig) vcpu mem balloon initialBalloonMem deflateOnOOM hotplugMem hotpluggedMem user interfaces volumes shares socket devices hugepageMem graphics storeDisk storeOnDisk kernel initrdPath credentialFiles vsock;
+  inherit (microvmConfig) vcpu mem balloon initialBalloonMem deflateOnOOM hotplugMem hotpluggedMem user interfaces volumes shares socket devices hugepageMem graphics storeDisk storeOnDisk storeDiskDirect kernel initrdPath credentialFiles vsock;
   inherit (microvmConfig.cloud-hypervisor) platformOEMStrings extraArgs;
 
   # extract all the extra args that we merge with up front
@@ -233,7 +233,11 @@ in {
         lib.optional storeOnDisk (opsMapped ({
           path = toString storeDisk;
           readonly = "on";
-        } // mqOps))
+        } //
+        lib.optionalAttrs storeDiskDirect {
+          direct = "on";
+        } //
+        mqOps))
         ++
         map ({ image, serial, direct, readOnly, imageType, ... }:
           opsMapped (

--- a/lib/runners/crosvm.nix
+++ b/lib/runners/crosvm.nix
@@ -11,7 +11,7 @@ let
   inherit (microvmConfig)
     vcpu mem balloon initialBalloonMem hotplugMem hotpluggedMem user volumes shares
     socket devices vsock graphics credentialFiles
-    kernel initrdPath storeDisk storeOnDisk;
+    kernel initrdPath storeDisk storeOnDisk storeDiskDirect;
   inherit (microvmConfig.crosvm) pivotRoot extraArgs;
 
   crosvmPkg = microvmConfig.crosvm.package;
@@ -80,7 +80,7 @@ in {
       )
       ++
       lib.optionals storeOnDisk [
-        "-r" storeDisk
+        "-r" "${storeDisk}${lib.optionalString storeDiskDirect ",o_direct=true"}"
       ]
       ++
       lib.optionals graphics.enable [

--- a/lib/runners/firecracker.nix
+++ b/lib/runners/firecracker.nix
@@ -12,7 +12,7 @@ let
     vcpu mem balloon initialBalloonMem hotplugMem hotpluggedMem
     interfaces volumes shares devices
     kernel initrdPath
-    storeDisk credentialFiles vsock;
+    storeDisk storeDiskDirect credentialFiles vsock;
   inherit (microvmConfig.firecracker) cpu;
 
   kernelPath = {
@@ -98,6 +98,8 @@ in {
     then throw "hotpluggedMem not implemented for Firecracker"
     else if credentialFiles != {}
     then throw "credentialFiles are not implemented for Firecracker"
+    else if storeDiskDirect
+    then throw "storeDiskDirect is not implemented for Firecracker"
     else lib.escapeShellArgs ([
       "${firecrackerPkg}/bin/firecracker"
       "--config-file" configFile

--- a/lib/runners/kvmtool.nix
+++ b/lib/runners/kvmtool.nix
@@ -13,7 +13,7 @@ let
     hostName preStart user
     vcpu mem balloon initialBalloonMem hotplugMem hotpluggedMem interfaces volumes shares devices vsock
     kernel initrdPath credentialFiles
-    storeDisk storeOnDisk;
+    storeDisk storeOnDisk storeDiskDirect;
 in {
   preStart = ''
     ${preStart}
@@ -45,7 +45,9 @@ in {
       ]
       ++
       lib.optionals storeOnDisk [
-        "-d" (lib.escapeShellArg "${storeDisk},ro")
+        "-d" (lib.escapeShellArg "${storeDisk}${
+          lib.optionalString storeDiskDirect ",direct"
+        },ro")
       ]
       ++
       lib.optionals balloon [ "--balloon" ]

--- a/lib/runners/qemu.nix
+++ b/lib/runners/qemu.nix
@@ -38,7 +38,7 @@ let
     then "io_uring"
     else "threads";
 
-  inherit (microvmConfig) hostName machineId vcpu mem balloon initialBalloonMem deflateOnOOM hotplugMem hotpluggedMem user interfaces shares socket forwardPorts devices vsock graphics storeOnDisk kernel initrdPath storeDisk credentialFiles;
+  inherit (microvmConfig) hostName machineId vcpu mem balloon initialBalloonMem deflateOnOOM hotplugMem hotpluggedMem user interfaces shares socket forwardPorts devices vsock graphics storeOnDisk kernel initrdPath storeDisk storeDiskDirect credentialFiles;
   inherit (microvmConfig.qemu) machine extraArgs serialConsole pcieRootPorts;
 
   volumes = withDriveLetters microvmConfig;
@@ -232,7 +232,9 @@ lib.warnIf (mem == 2048) ''
       "-append" "${kernelConsole} reboot=t panic=-1 ${toString microvmConfig.kernelParams}"
     ] ++
     lib.optionals storeOnDisk [
-      "-drive" "id=store,format=raw,read-only=on,file=${storeDisk},if=none,aio=${aioEngine}"
+      "-drive" "id=store,format=raw,read-only=on,file=${storeDisk},if=none,aio=${aioEngine}${
+        lib.optionalString storeDiskDirect ",cache=none"
+      }"
       "-device" "virtio-blk-${devType},drive=store${lib.optionalString (devType == "pci") ",disable-legacy=on"}"
     ] ++
        (if graphics.enable then (

--- a/lib/runners/stratovirt.nix
+++ b/lib/runners/stratovirt.nix
@@ -16,7 +16,7 @@ let
     hostName
     vcpu mem balloon initialBalloonMem hotplugMem hotpluggedMem interfaces shares socket forwardPorts devices
     kernel initrdPath credentialFiles
-    storeOnDisk storeDisk;
+    storeOnDisk storeDisk storeDiskDirect;
 
   tapMultiQueue = vcpu > 1;
 
@@ -103,7 +103,9 @@ in {
       "-device" "virtio-rng-${devType 1},rng=rng,id=rng_dev"
     ] ++
     lib.optionals storeOnDisk [
-      "-drive" "id=store,format=raw,readonly=on,file=${storeDisk},if=none,aio=io_uring,direct=false"
+      "-drive" "id=store,format=raw,readonly=on,file=${storeDisk},if=none,aio=io_uring,direct=${
+        lib.boolToString storeDiskDirect
+      }"
       "-device" "virtio-blk-${devType 2},drive=store,id=blk_store"
     ] ++
     lib.optionals (socket != null) [ "-qmp" "unix:${socket},server,nowait" ] ++

--- a/lib/runners/vfkit.nix
+++ b/lib/runners/vfkit.nix
@@ -14,7 +14,7 @@ let
 
   inherit (microvmConfig)
     vcpu mem user interfaces shares socket
-    storeOnDisk storeDisk kernel initrdPath kernelParams
+    storeOnDisk storeDisk storeDiskDirect kernel initrdPath kernelParams
     balloon devices credentialFiles vsock graphics;
 
   inherit (microvmConfig.vfkit) extraArgs logLevel rosetta;
@@ -117,6 +117,8 @@ in
     then throw "vfkit does not support credentialFiles"
     else if vsock.cid != null
     then throw "vfkit vsock support not yet implemented in microvm.nix"
+    else if storeDiskDirect
+    then throw "vfkit does not support storeDiskDirect"
     else
       let
         baseCmd = lib.escapeShellArgs allArgsWithoutSocket;

--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -1058,6 +1058,23 @@ in
       default = [ "-c" "zstd" "-j" "$NIX_BUILD_CORES" ];
     };
 
+    storeDiskDirect = mkOption {
+      type = types.bool;
+      default = builtins.elem config.microvm.hypervisor self-lib.hypervisorsWithStoreDiskDirect;
+      defaultText = lib.literalExpression ''builtins.elem config.microvm.hypervisor ${lib.generators.toPretty { multiline = false; } self-lib.hypervisorsWithStoreDiskDirect}'';
+      description = ''
+        Whether to open the `microvm.storeDisk` image with O_DIRECT,
+        bypassing the host page cache like `microvm.volumes.*.direct`.
+        The guest caches the store disk itself, so the host copy is
+        normally redundant.
+
+        Enabled by default on the hypervisors that support it:
+        ${lib.concatStringsSep ", " self-lib.hypervisorsWithStoreDiskDirect}.
+        Enabling it on any other hypervisor is an error. Set to `false`
+        if the store disk lives on a filesystem without O_DIRECT support.
+      '';
+    };
+
     systemSymlink = mkOption {
       type = types.bool;
       default = !config.microvm.storeOnDisk;


### PR DESCRIPTION
## Summary

`microvm.volumes.*.direct` already lets a volume bypass the host page cache, but the generated `microvm.storeDisk` was always opened buffered. This adds `microvm.storeDiskDirect` (default `true` on supported VMs, otherwise `false`) and passes it through for every hypervisor that takes a per-disk direct-I/O flag:

| Hypervisor | Store disk argument when enabled |
|---|---|
| crosvm | `-r <disk>,o_direct=true` |
| qemu | `-drive id=store,...,cache=none` |
| cloud-hypervisor | `--disk path=<disk>,readonly=on,direct=on` |
| kvmtool | `-d <disk>,direct,ro` |
| stratovirt | `-drive id=store,...,direct=true` (was hard-coded `direct=false`) |
| firecracker, alioth, vfkit | error |

**Behavior change:** existing configurations on the five supported hypervisors now open the store disk with O_DIRECT. Set `microvm.storeDiskDirect = false` to restore buffered reads, e.g. if `/nix/store` is on a filesystem without O_DIRECT support. Noted in CHANGELOG.md.

## Motivation

The store disk is the one image a MicroVM cannot open with direct I/O. Without direct I/O, each block the guest reads from it is cached twice - once in the host page cache and once in the guest's own page cache, which is wasteful esp. on small hosts.

## Testing

- Evaluated the runner command for each hypervisor with the option on and off from a minimal `nixosSystem`; the only differences are the arguments in the table above, and firecracker, alioth, and vfkit raise an error.
- Tested end-to-end on my nixos box running a crosvm guest