### PR TITLE
fix: Avoid uploading disk image to remote builders

### DIFF
--- a/lib/runner.nix
+++ b/lib/runner.nix
@@ -211,7 +211,7 @@ let
   ) binScripts;
 in
 
-vmHostPackages.buildPackages.runCommand "microvm-${microvmConfig.hypervisor}-${hostName}"
+vmHostPackages.buildPackages.runCommandLocal "microvm-${microvmConfig.hypervisor}-${hostName}"
 {
   # for `nix run`
   meta.mainProgram = "microvm-run";


### PR DESCRIPTION
I have remote builders configured and noticed after switching to `storeOnDisk =
true` the erofs disk would get built locally, but then still copied to the builder system. When roaming this is not ideal, since even a simple vm could have a ~1gb disk image. I tracked the issue down to the runner package build not using `runCommandLocal`, which much of the other code already uses.

The log without the fix and building microvms (neko, nano) with remote builders (oedo, oppo), looks roughly like the following (with irrelevant parts snipped):

```
building '/nix/store/8bbfj03qbl8kcyx0z9df5pl100d4inl8-microvm-store-disk.erofs.drv'...
building '/nix/store/k03m1w415dldx4c7kyplmjmhfra1yb41-microvm-store-disk.erofs.drv'...
building '/nix/store/asnppx12k0wrq0i9f7hrar2xjs6csspn-microvm-nano-microvm-run.drv'...
building '/nix/store/3xlskgy1cja872pagrk636rpdi4rnh6h-microvm-qemu-nano.drv' on 'ssh://builder@oppo'...
building '/nix/store/xsbm73ybdbp9g6jm6x8wyvzj8icap0q0-microvm-neko-microvm-run.drv'...
copying path '/nix/store/kc5gscs2i6w7wxbay1xwk7k92jdg9cm0-microvm-store-disk.erofs' to 'ssh://builder@oppo'...
building '/nix/store/krng4jirh4xqbb8cwbwzx0rz8za69gq7-microvm-qemu-neko.drv' on 'ssh://builder@oedo'...
copying path '/nix/store/g9bpzsvinzz49qkzghgp538cpx1ri7nw-microvm-store-disk.erofs' to 'ssh://builder@oedo'...
```

Running with this PR I no longer see the `microvm-store-disk.erofs` getting copied to the builders when the vms get rebuilt.
