### PR TITLE
crosvm: Add config options for vfio iommu and guestAddress

### DIFF
--- a/lib/runners/crosvm.nix
+++ b/lib/runners/crosvm.nix
@@ -148,8 +148,11 @@ in {
       ]
     )
     + " " + # Move vfio-pci outside of
-      lib.concatStringsSep " " (lib.concatMap ({ bus, path, ... }: {
-        pci = [ "--vfio" "/sys/bus/pci/devices/${path},iommu=viommu" ];
+      lib.concatStringsSep " " (lib.concatMap ({ bus, path, crosvm, ... }: let
+        iommu = if crosvm.iommu != null then crosvm.iommu else microvmConfig.crosvm.vfioIommu;
+        guestAddr = lib.optionalString (crosvm.guestAddress != null) ",guest-address=${crosvm.guestAddress}";
+      in {
+        pci = [ "--vfio" "/sys/bus/pci/devices/${path},iommu=${iommu}${guestAddr}" ];
         usb = throw "USB passthrough is not supported on crosvm";
       }.${bus}) devices)
     + " " + lib.escapeShellArgs extraArgs;

--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -487,6 +487,23 @@ in
               '';
             };
           };
+          crosvm = {
+            iommu = mkOption {
+              type = nullOr (enum [ "off" "viommu" "coiommu" "pkvm-iommu" ]);
+              default = null;
+              description = ''
+                IOMMU type to use for this VFIO device (optional)
+              '';
+            };
+            guestAddress = mkOption {
+              type = nullOr str;
+              default = null;
+              description = ''
+                PCI address to use for the VFIO device in the guest.
+                If not specified, defaults to mirroring the host PCI address.
+              '';
+            };
+          };
         };
       });
     };
@@ -829,6 +846,18 @@ in
       type = types.package;
       default = cfg.vmHostPackages.crosvm;
       defaultText = lib.literalExpression "config.microvm.vmHostPackages.crosvm";
+    };
+
+    crosvm.vfioIommu = mkOption {
+      type = with types; enum [ "off" "viommu" "coiommu" "pkvm-iommu" ];
+      default = "viommu";
+      description = ''
+        IOMMU type to use by default for VFIO devices.
+
+        This setting will be used as the default for all crosvm microvm.devices definitions.
+        The IOMMU type can be set independently for each device via the crosvm.iommu attribute,
+        in which case it will take precedence over this option.
+      '';
     };
 
     firecracker.cpu = mkOption {


### PR DESCRIPTION
Add support for missing vfio PCI parameters for the `--vfio` flag that are present in recent versions of crosvm.