### PR TITLE
feat: add DAX support for alioth and crosvm 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@
 * Per-share virtiofsd options: `microvm.shares.*.posixAcl` and
   `.extraArgs`, enabling per-share UID/GID remapping via
   `--translate-uid` / `--translate-gid`.
+* Per-share **DAX** for virtiofs shares: `microvm.shares.*.dax` and
+  `.daxWindowSize`, supported on **alioth** and **crosvm**. On crosvm
+  such a share bypasses virtiofsd and is served by crosvm's own
+  built-in virtio-fs device, so `microvm.virtiofsd.warnOnIgnoredExtraArgs`
+  warns about `extraArgs` that no longer apply.
 * Add the [alioth VMM](https://github.com/google/alioth)
 * Fixes for the stratovirt VMM
 * New volume image files will be created with `truncate` instead of

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -116,6 +116,23 @@ let
           ];
         };
       }) ];
+    } {
+      id = "virtiofs-dax";
+      modules = [ ({ config, ... }: {
+        microvm = {
+          shares = [ {
+            proto = "virtiofs";
+            tag = "test-dax";
+            source = "/nix/store";
+            mountPoint = "/nix/.ro-store";
+            dax = true;
+          } ];
+          testing.enableTest = builtins.elem config.microvm.hypervisor [
+            # Hypervisors that support DAX
+            "alioth" "crosvm"
+          ];
+        };
+      }) ];
     } ]
     # rw-store
     [ {

--- a/doc/src/conventions.md
+++ b/doc/src/conventions.md
@@ -16,6 +16,10 @@ MicroVM deployments using the information on this page.
 | `microvm.shares.*.socket`    | `share/microvm/virtiofs/${tag}/socket` | `microvm-virtiofsd@.service`        | **virtiofsd** socket path by tag                                                              |
 | `microvm.systemSymlink`      | `share/microvm/system`                 |                                     | `config.system.build.toplevel` symlink, used for comparing versions when running `microvm -l` |
 
+The `share/microvm/virtiofs/${tag}/` entries only exist for shares
+served by virtiofsd. A [`dax = true`](shares.md#dax) share on **crosvm**
+runs no virtiofsd, so it gets no directory here.
+
 
 ## Generating custom operating system hypervisor packages
 

--- a/doc/src/shares.md
+++ b/doc/src/shares.md
@@ -73,6 +73,42 @@ microvm.shares = [ {
 `[HOST_UID, HOST_UID+COUNT)` on the host.
 
 
+## DAX
+
+DAX lets the guest map file contents straight from the host's page
+cache instead of copying them through the virtqueue, which helps for
+frequently accessed files. See the [virtio-fs design
+doc](https://virtio-fs.gitlab.io/design.html) for details.
+
+Only **alioth** and **crosvm** support it; `dax = true` on any other
+hypervisor is an evaluation error.
+
+```nix
+microvm.shares = [ {
+  proto = "virtiofs";
+  tag = "assets";
+  source = "/var/lib/microvms/example/assets";
+  mountPoint = "/assets";
+  dax = true;
+} ];
+```
+
+The guest mounts with `-o dax=always`, so the mount fails loudly
+instead of silently falling back if there is no DAX window.
+
+`daxWindowSize` sets the window size in megabytes. Only alioth honors
+it; crosvm hard-codes 8GiB, which is the default.
+
+On **alioth** nothing else changes: the window is requested on the
+same vhost-user device, and virtiofsd still serves the share.
+
+On **crosvm** virtiofsd cannot do DAX, so the share is handed to
+crosvm's own built-in virtio-fs device instead. That share therefore
+has no `socket` and runs no virtiofsd, which means `extraArgs` and
+`microvm.virtiofsd.extraArgs` are ignored (warned about, silence with
+`microvm.virtiofsd.warnOnIgnoredExtraArgs = false`), and `readOnly` is
+rejected.
+
 ## Sharing a host's `/nix/store`
 
 If a share with `source = "/nix/store"` is defined, size and build

--- a/lib/runner.nix
+++ b/lib/runner.nix
@@ -257,7 +257,8 @@ vmHostPackages.buildPackages.runCommandLocal "microvm-${microvmConfig.hypervisor
 
 
   ${lib.concatMapStrings ({ tag, socket, source, proto, ... }:
-      lib.optionalString (proto == "virtiofs") ''
+      # DAX shares on crosvm have no socket: they run no virtiofsd.
+      lib.optionalString (proto == "virtiofs" && socket != null) ''
         mkdir -p $out/share/microvm/virtiofs/${tag}
         echo "${socket}" > $out/share/microvm/virtiofs/${tag}/socket
         echo "${source}" > $out/share/microvm/virtiofs/${tag}/source

--- a/lib/runners/alioth.nix
+++ b/lib/runners/alioth.nix
@@ -58,10 +58,17 @@ in {
           ]
       ) volumes
       ++
-      builtins.concatMap ({ proto, socket, tag, ... }:
+      builtins.concatMap ({ proto, socket, tag, dax, daxWindowSize, ... }:
         if proto == "virtiofs"
         then [
-          "--fs" (lib.escapeShellArg "vu,socket=${socket},tag=${tag}")
+          "--fs" (lib.escapeShellArg (lib.concatStringsSep "," ([
+            "vu"
+            "socket=${socket}"
+            "tag=${tag}"
+          ] ++ lib.optional dax
+            # dax_window is in bytes; omitting it means no DAX.
+            "dax_window=${toString (daxWindowSize * 1024 * 1024)}"
+          )))
         ] else throw "9p shares not implemented for alioth"
       ) shares
       ++

--- a/lib/runners/crosvm.nix
+++ b/lib/runners/crosvm.nix
@@ -108,10 +108,17 @@ in {
         ]
       ) volumes
       ++
-      builtins.concatMap ({ proto, tag, source, socket, readOnly, ... }: {
-        "virtiofs" = [
-          "--vhost-user" "type=fs,socket=${socket}"
-        ];
+      builtins.concatMap ({ proto, tag, source, socket, readOnly, dax, cache, posixAcl, ... }: {
+        "virtiofs" =
+          if dax
+          then
+            # virtiofsd never negotiates VHOST_USER_PROTOCOL_F_SHMEM_MAP,
+            # so crosvm's vhost-user frontend cannot expose a DAX window.
+            # Use crosvm's own built-in virtio-fs device instead.
+            [ "--shared-dir" "${source}:${tag}:type=fs:dax=true:cache=${cache}:posix_acl=${lib.boolToString posixAcl}" ]
+          else [
+            "--vhost-user" "type=fs,socket=${socket}"
+          ];
         "9p" = if readOnly then
           throw "Readonly 9p share is not supported"
         else [

--- a/nixos-modules/microvm/asserts.nix
+++ b/nixos-modules/microvm/asserts.nix
@@ -2,6 +2,15 @@
 let
   inherit (config.networking) hostName;
 
+  # DAX shares served by crosvm's built-in device instead of virtiofsd
+  daxBypassShares = builtins.filter ({ proto, dax, ... }:
+    proto == "virtiofs" && dax && config.microvm.hypervisor == "crosvm"
+  ) config.microvm.shares;
+
+  # whether any share still spawns virtiofsd
+  anyVirtiofsdShares = builtins.any ({ proto, dax, ... }:
+    proto == "virtiofs" && !(dax && config.microvm.hypervisor == "crosvm")
+  ) config.microvm.shares;
 in
 lib.mkIf config.microvm.guest.enable {
   assertions =
@@ -84,15 +93,42 @@ lib.mkIf config.microvm.guest.enable {
       )
     )
     ++
-    # check for virtiofs shares without socket
-    map ({ tag, socket, ... }: {
-      assertion = socket != null;
+    # check for virtiofs shares without socket (DAX on crosvm needs none)
+    map ({ tag, socket, dax, ... }: {
+      assertion = socket != null || (dax && config.microvm.hypervisor == "crosvm");
       message = ''
         MicroVM ${hostName}: virtiofs share with tag "${tag}" is missing a `socket` path.
       '';
     }) (
       builtins.filter ({ proto, ... }: proto == "virtiofs")
         config.microvm.shares
+    )
+    ++
+    # check for DAX shares on unsupported hypervisors
+    map ({ tag, ... }: {
+      assertion = builtins.elem config.microvm.hypervisor [ "alioth" "crosvm" ];
+      message = ''
+        MicroVM ${hostName}: virtiofs share "${tag}" has dax=true, but DAX is
+        only supported with the alioth and crosvm hypervisors
+        (currently: ${config.microvm.hypervisor}).
+      '';
+    }) (
+      builtins.filter ({ proto, dax, ... }: proto == "virtiofs" && dax)
+        config.microvm.shares
+    )
+    ++
+    # crosvm's built-in virtio-fs device has no read-only mode
+    map ({ tag, ... }: {
+      assertion = false;
+      message = ''
+        MicroVM ${hostName}: virtiofs share "${tag}" combines dax=true with
+        readOnly=true, which crosvm's built-in DAX device cannot do.
+      '';
+    }) (
+      builtins.filter ({ proto, dax, readOnly, ... }:
+        proto == "virtiofs" && dax && readOnly &&
+        config.microvm.hypervisor == "crosvm"
+      ) config.microvm.shares
     )
     ++
     # check for virtiofs shares where posixAcl conflicts with translate-uid/gid
@@ -142,5 +178,22 @@ lib.mkIf config.microvm.guest.enable {
     ''
     ++ lib.optional config.nix.optimise.automatic ''
       Optimising the nix store is not recommended as it either uses lots of file handles with virtiofsd or as it doesn't do what you expect with a block device.
-    '';
+    ''
+    ++ lib.optionals config.microvm.virtiofsd.warnOnIgnoredExtraArgs (
+      map ({ tag, ... }: ''
+        MicroVM ${hostName}: `extraArgs` of virtiofs share "${tag}" are ignored:
+        dax=true on crosvm runs no virtiofsd.
+        Set `microvm.virtiofsd.warnOnIgnoredExtraArgs = false` to silence this.
+      '') (builtins.filter ({ extraArgs, ... }: extraArgs != []) daxBypassShares)
+      ++
+      lib.optional (
+        config.microvm.virtiofsd.extraArgs != [] &&
+        daxBypassShares != [] &&
+        !anyVirtiofsdShares
+      ) ''
+        MicroVM ${hostName}: `microvm.virtiofsd.extraArgs` has no effect: every
+        virtiofs share has dax=true on crosvm, so no virtiofsd runs.
+        Set `microvm.virtiofsd.warnOnIgnoredExtraArgs = false` to silence this.
+      ''
+    );
 }

--- a/nixos-modules/microvm/mounts.nix
+++ b/nixos-modules/microvm/mounts.nix
@@ -117,12 +117,15 @@ lib.mkIf config.microvm.guest.enable {
       }) {} (withDriveLetters config.microvm)
   ) (
     # 9p/virtiofs Shares
-    builtins.foldl' (result: { mountPoint, tag, proto, source, ... }: result // {
+    builtins.foldl' (result: { mountPoint, tag, proto, source, dax, ... }: result // {
       "${mountPoint}" = {
         device = tag;
         fsType = proto;
         options = {
-          "virtiofs" = [ "defaults" "x-systemd.after=systemd-modules-load.service" ];
+          "virtiofs" = [ "defaults" "x-systemd.after=systemd-modules-load.service" ]
+            # The kernel defaults to per-inode DAX; request it for the
+            # whole mount, which also fails loudly without a DAX window.
+            ++ lib.optional dax "dax=always";
           "9p" = [ "trans=virtio" "version=9p2000.L" "msize=65536" "x-systemd.after=systemd-modules-load.service" ];
         }.${proto};
       } // lib.optionalAttrs (source == "/nix/store" || mountPoint == config.microvm.writableStoreOverlay) {

--- a/nixos-modules/microvm/options.nix
+++ b/nixos-modules/microvm/options.nix
@@ -382,10 +382,14 @@ in
           socket = mkOption {
             type = nullOr str;
             default =
-              if config.proto == "virtiofs"
+              if config.proto == "virtiofs" && !(config.dax && cfg.hypervisor == "crosvm")
               then "${hostName}-virtiofs-${config.tag}.sock"
               else null;
-            description = "Socket for communication with virtiofs daemon";
+            description = ''
+              Socket for communication with virtiofs daemon.
+
+              `null` for a DAX share on crosvm, which runs no virtiofsd.
+            '';
           };
           source = mkOption {
             type = nonEmptyStr;
@@ -428,6 +432,31 @@ in
             type = listOf str;
             default = [];
             description = "Extra arguments passed to virtiofsd for this share.";
+          };
+          dax = mkOption {
+            type = bool;
+            default = false;
+            description = ''
+              Enable DAX for this virtiofs share, letting the guest map file
+              contents directly from the host's page cache. Ignored unless
+              `proto` is `"virtiofs"`.
+
+              Only `alioth` and `crosvm` support this. virtiofsd cannot do
+              DAX, so on crosvm the share is served by crosvm's own built-in
+              virtio-fs device instead: it gets no `socket`, ignores
+              `extraArgs`, and cannot be `readOnly`.
+            '';
+          };
+          daxWindowSize = mkOption {
+            type = types.ints.positive;
+            default = 8192;
+            example = 4096;
+            description = ''
+              Size of the DAX window in megabytes, used when `dax = true`.
+
+              Only `alioth` honors this. The default matches the 8GiB
+              window that crosvm hard-codes.
+            '';
           };
         };
       }));
@@ -992,6 +1021,15 @@ in
       default = [];
       description = ''
         Extra command-line switch to pass to virtiofsd.
+      '';
+    };
+
+    virtiofsd.warnOnIgnoredExtraArgs = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Warn about `extraArgs` that have no effect because a `dax = true`
+        share on crosvm runs no virtiofsd (see `microvm.shares.*.dax`).
       '';
     };
 

--- a/nixos-modules/microvm/virtiofsd/default.nix
+++ b/nixos-modules/microvm/virtiofsd/default.nix
@@ -1,8 +1,10 @@
 { config, lib, pkgs, ... }:
 
 let
-  virtiofsShares = builtins.filter ({ proto, ... }:
-    proto == "virtiofs"
+  virtiofsShares = builtins.filter ({ proto, dax, ... }:
+    proto == "virtiofs" &&
+    # DAX shares on crosvm are served by crosvm's built-in device
+    !(dax && config.microvm.hypervisor == "crosvm")
   ) config.microvm.shares;
 
   requiresVirtiofsd = virtiofsShares != [] && config.microvm.hypervisor != "vfkit";


### PR DESCRIPTION
Added DAX support for virtiofs shares

Opt-in `dax` per virtiofs share, on the two hypervisors that actually implement it.
The guest mounts with `-o dax=always`, so it fails loudly rather than silently degrading if there is no DAX window.

1. **Added DAX support for crosvm**
   virtiofsd can't negotiate a DAX window, so the share goes to crosvm's built-in virtio-fs device instead: no socket, no virtiofsd, no `readOnly`.
   crosvm's window is a fixed 8GiB, so it ignores `daxWindowSize`.

2. **Added DAX support for alioth**
   DAX works on the existing device virtiofsd device and honors `daxWindowSize`.

3. **Added a `virtiofs-dax` check variant**
   Boots a VM with a DAX `/nix/store` share on both hypervisors.
   `dax=always` makes the kernel refuse the mount without a real window, so passing proves it works.

4. **Documentation**
   Added docs covering the new options, the crosvm caveats, and why the other hypervisors are absent.
   Added DAX note to changelog

## Hypervisor support

| Hypervisor | DAX | Notes |
|---|---|---|
| alioth | yes | configurable window |
| crosvm | yes | fixed 8GiB window |
| cloud-hypervisor | no | `docs/fs.md`: "not available"; `--fs` rejects `dax` |
| qemu | no | dropped `cache-size` on `vhost-user-fs-pci` |
| stratovirt, vfkit | no | no DAX at all |
| firecracker, kvmtool | n/a | no virtiofs shares |

Some refs:

- https://virtio-fs.gitlab.io/design.html
- https://lwn.net/Articles/813807/
- https://www.kernel.org/doc/html/latest/filesystems/dax.html
