### PR TITLE
docs: fix the microvm.runner and qemu interface type names

### DIFF
--- a/doc/src/output-options.md
+++ b/doc/src/output-options.md
@@ -6,7 +6,7 @@ nixosSystem for you to use inside and outside your configuration.
 | Option                   | Purpose                                                   |
 |--------------------------|-----------------------------------------------------------|
 | `microvm.declaredRunner` | Runner package selected according to `microvm.hypervisor` |
-| `microvm.runners`        | Attribute set of runner packages per known Hypervisor.    |
+| `microvm.runner`         | Attribute set of runner packages per known Hypervisor.    |
 
 The `microvm.declaredRunner` selects the hypervisor according to the
 configured `microvm.hypervisor`.
@@ -15,21 +15,21 @@ configured `microvm.hypervisor`.
 nix run .#nixosConfigurations.my-microvm.config.microvm.declaredRunner
 ```
 
-The `microvm.runners` option provides a runner for each known
+The `microvm.runner` option provides a runner for each known
 Hypervisor regardless of the `microvm.hypervisor` config setting. To
 build *my-microvm* for Firecracker for example:
 
 ```bash
-nix run .#nixosConfigurations.my-microvm.config.microvm.runners.firecracker
+nix run .#nixosConfigurations.my-microvm.config.microvm.runner.firecracker
 ```
 
 ## Configure `microvm.hypervisor`, use `microvm.declaredRunner`!
 
-One of the `microvm.runners` is picked by `microvm.declaredRunner` by
+One of the `microvm.runner` packages is picked by `microvm.declaredRunner` by
 evaluating `microvm.hypervisor`.
 
 You may switch the Hypervisor quickly, but use `declaredRunner` in
 production. Any other NixOS configuration that evaluates the
 `microvm.hypervisor` option can be wrong when you pick from
-`microvm.runners` directly. One example would be the defaults set by
+`microvm.runner` directly. One example would be the defaults set by
 `microvm.optimize`.

--- a/doc/src/packages.md
+++ b/doc/src/packages.md
@@ -5,7 +5,7 @@ to interact with its console.
 
 There are drawbacks: no preparation for TAP network interfaces is done
 and no virtiofsd is started. These can be worked around by relying on
-9p shares and using qemu's `host` network interfaces.
+9p shares and using qemu's `user` network interfaces.
 
 ## Immediately running a nixosConfiguration
 


### PR DESCRIPTION
The handbook hands you a `nix run` command that can't work: it asks for `microvm.runners`, but that attribute isnt declared and there's no compatibility alias for it.

| Handbook says | Actually called |
| --- | --- |
| `microvm.runners` | `microvm.runner` |
| qemu interface type `host` | qemu interface type `user` |

The option is declared as `runner`, populated as `microvm.runner`, and every consumer reads the singluar name. "Hypervisor runners" remains unchanged where it's ordinary prose.

This hits anyone using the output-options page to build for a hypervisor other than their configured default - the command you've been given can't resolve. The packages page has the same problem for anyone running a MicroVM as a plain package without TAP networking. `microvm.interfaces.*.type` is the strict enum `[ "user" "tap" "macvtap" "bridge" ]`, so `host` causes an evaluation failure. You then waste time working out the handbook is wrong, not your config.

Only these two handbook pages change. The generated options reference already prints `microvm.runner` correctly and doesnt need touching.

The `host` wording came from commit `92b2482` in April 2022. It was wrong then too: the enum was `[ "user" "tap" "bridge" ]`, so `host` has never been legal. `git log -S` finds that one commit and no later change.
