### PR TITLE
qemu: do not enable test runner patch that forces p9 shares to be root owned

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1785692966,
-        "narHash": "sha256-vUfIeBEfpbAfZ5zjgIkYk7eHBeVfCYVjLbWnMkseYnk=",
+        "lastModified": 1789006805,
+        "narHash": "sha256-xB8mKMOx1IA9vTDNLmJZ6n4wCMq/cuWBBOzGCRnqxrU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "643809054d65fdd466a63e3155b8c498cb483c04",
+        "rev": "8ce4ef6cb6f871616146b9fe26d2a5ae594e94fe",
         "type": "github"
       },
       "original": {
@@ -25,11 +25,11 @@
     "spectrum": {
       "flake": false,
       "locked": {
-        "lastModified": 1785761586,
-        "narHash": "sha256-MWOMVqJJERwjQGgRIv8d6rlEBqbLM3VZWxHkNKIIZNw=",
+        "lastModified": 1786032750,
+        "narHash": "sha256-+Ba/kIn5BjvV7PN8bWOo7RoqgTY/Yv2M7qeMf3wS2Ag=",
         "ref": "refs/heads/main",
-        "rev": "a7762d6f54b40560dd5255ce902e6e6a5d980fe9",
-        "revCount": 1416,
+        "rev": "77d2389874bb092b8dbf05ecc5b1030372e80e98",
+        "revCount": 1417,
         "type": "git",
         "url": "https://spectrum-os.org/git/spectrum"
       },

--- a/lib/runners/qemu.nix
+++ b/lib/runners/qemu.nix
@@ -20,13 +20,10 @@ let
     ];
   });
 
-  minimizeQemuClosureSize = pkg: pkg.override (oa: {
+  minimizeQemuClosureSize = pkg: pkg.override {
     # standin for disabling everything guilike by hand
-    nixosTestRunner =
-      if graphics.enable
-      then oa.nixosTestRunner or false
-      else true;
-  });
+    minimal = !graphics.enable;
+  };
 
   overrideQemu = x: lib.pipe x (
     lib.optional requireUsb enableLibusb


### PR DESCRIPTION
Closes #599

will be cached with https://github.com/NixOS/nixpkgs/pull/562414